### PR TITLE
Create record #4

### DIFF
--- a/app/(authenticated)/dairyrecord/page.tsx
+++ b/app/(authenticated)/dairyrecord/page.tsx
@@ -1,12 +1,14 @@
 import Caluculator from "@/app/components/page/DairyRecord/Caluculator";
+import Submit from "@/app/components/page/DairyRecord/Submit";
 
 export default function DairyRecordPage() {
     return (
       <>
-      <div className="flex flex-col justify-center items-center m-auto p-6 z-0">
+      <div className="flex flex-col md:flex-row justify-center items-center m-auto p-6 z-0 md:gap-x-6 max-w-3xl mx-auto">
         <Caluculator/>
+        <Submit/>
       </div>
       </>
     )
-  }
+}
   

--- a/app/(authenticated)/dairyrecord/page.tsx
+++ b/app/(authenticated)/dairyrecord/page.tsx
@@ -11,4 +11,3 @@ export default function DairyRecordPage() {
       </>
     )
 }
-  

--- a/app/(authenticated)/dairyrecord/page.tsx
+++ b/app/(authenticated)/dairyrecord/page.tsx
@@ -1,8 +1,10 @@
+import Caluculator from "@/app/components/page/DairyRecord/Caluculator";
+
 export default function DairyRecordPage() {
     return (
       <>
-      <div className="flex justify-center items-center">
-        <p>売上記録ページです</p>
+      <div className="flex flex-col justify-center items-center m-auto p-6 z-0">
+        <Caluculator/>
       </div>
       </>
     )

--- a/app/(authenticated)/dairyrecord/page.tsx
+++ b/app/(authenticated)/dairyrecord/page.tsx
@@ -4,7 +4,7 @@ import Submit from "@/app/components/page/DairyRecord/Submit";
 export default function DairyRecordPage() {
     return (
       <>
-      <div className="flex flex-col md:flex-row justify-center items-center m-auto p-6 z-0 md:gap-x-6 max-w-3xl mx-auto">
+      <div className="flex flex-col md:flex-row justify-center items-center mx-auto p-6 z-0 md:gap-x-6 max-w-5xl my-10">
         <Caluculator/>
         <Submit/>
       </div>

--- a/app/(authenticated)/layout.tsx
+++ b/app/(authenticated)/layout.tsx
@@ -8,11 +8,9 @@ export default function AuthenticatedLayout({
 
   return (
     <>
-      <div className="flex flex-col justify-center items-center min-h-screen">
         <RequireAuth>
         {children}
         </RequireAuth>
-      </div>
     </>
   )
 }

--- a/app/api/dairyrecord/route.ts
+++ b/app/api/dairyrecord/route.ts
@@ -15,12 +15,13 @@ export async function POST(request: Request) {
     });
   }
 
-  // リクエストボディの解析, dairy_recordが存在するかチェック
+  // リクエストボディの解析, dairy_recordが存在するか検証のちバックエンドに送信
   const data = await request.json();
   const dairy_record = data.dairy_record;
+  const customer_counts = data.customer_counts;
 
-  if (!dairy_record) {
-    return new Response(JSON.stringify({ error: 'dairy_recordがありません' }), {
+  if (!dairy_record || !customer_counts){
+    return new Response(JSON.stringify({ error: 'dairy_recordまたはcustomer_countsがありません' }), {
         status: 400,
         headers: {
             "Content-Type": "application/json"
@@ -29,18 +30,21 @@ export async function POST(request: Request) {
   }
 
   dairy_record.user_id = session.user.railsId;
-
   const apiUrl = process.env.RAILS_API_URL
 
   try {
-    const response = await axios.post(`${apiUrl}/dairy_records`, { dairy_record });
+    const response = await axios.post(`${apiUrl}/dairy_records`, { 
+      dairy_record,
+      customer_counts
+    });
       return new Response(JSON.stringify(response.data), {
         status: 200,
         headers: {
             "Content-Type": "application/json",
         },
     });
-  } catch (error) {        
+  } catch (error) {
+    console.error("Error caught in API route:", error);       
     return new Response(JSON.stringify({ error: '予期せぬエラーが発生しました'  }), {
         status: 500,
         headers: {

--- a/app/api/dairyrecord/route.ts
+++ b/app/api/dairyrecord/route.ts
@@ -1,0 +1,51 @@
+import axios from 'axios';
+import { getServerSession } from "next-auth/next"
+import { options } from '@/lib/options';
+
+export async function POST(request: Request) {
+
+  const session = await getServerSession(options);
+    
+  if (!session) {
+    return new Response(JSON.stringify({ error: '認証が必要です' }), {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  // リクエストボディの解析, dairy_recordが存在するかチェック
+  const data = await request.json();
+  const dairy_record = data.dairy_record;
+
+  if (!dairy_record) {
+    return new Response(JSON.stringify({ error: 'dairy_recordがありません' }), {
+        status: 400,
+        headers: {
+            "Content-Type": "application/json"
+        }
+    });
+  }
+
+  dairy_record.user_id = session.user.railsId;
+
+  const apiUrl = process.env.RAILS_API_URL
+
+  try {
+    const response = await axios.post(`${apiUrl}/dairy_records`, { dairy_record });
+      return new Response(JSON.stringify(response.data), {
+        status: 200,
+        headers: {
+            "Content-Type": "application/json",
+        },
+    });
+  } catch (error) {        
+    return new Response(JSON.stringify({ error: '予期せぬエラーが発生しました'  }), {
+        status: 500,
+        headers: {
+            "Content-Type": "application/json",
+        },
+    });
+  }
+}

--- a/app/api/dairyrecord/route.ts
+++ b/app/api/dairyrecord/route.ts
@@ -44,11 +44,11 @@ export async function POST(request: Request) {
         },
     });
   } catch (error) {
-    console.error("Error caught in API route:", error);       
+    console.error(error); 
     return new Response(JSON.stringify({ error: '予期せぬエラーが発生しました'  }), {
         status: 500,
         headers: {
-            "Content-Type": "application/json",
+          "Content-Type": "application/json",
         },
     });
   }

--- a/app/components/base/Footer.tsx
+++ b/app/components/base/Footer.tsx
@@ -2,7 +2,7 @@ import { CloudIcon } from "@heroicons/react/24/outline";
 
 export default function Footer() {
   return (
-    <footer className="sticky bottom-0 text-gray-600 body-font bg-white">
+    <footer className="text-gray-600 body-font bg-white">
       <div className="container px-5 p-5 mx-auto flex flex-col sm:flex-row items-center">
         {/* アプリ名 + コピーライト*/}
         <div className="flex flex-row justify-center items-center">

--- a/app/components/base/Header.tsx
+++ b/app/components/base/Header.tsx
@@ -4,7 +4,7 @@ import DrawerMenu from "./DrawerMenu";
 
 export default function Header() {
   return (
-    <header className="sticky top-0 text-gray-600 body-font bg-white">
+    <header className="sticky top-0 text-gray-600 body-font bg-white z-50">
       <div className="container mx-auto flex flex-wrap p-5 items-center justify-between">
         <div className="flex items-center">
         <span className="md:hidden"><DrawerMenu/></span>

--- a/app/components/base/Header.tsx
+++ b/app/components/base/Header.tsx
@@ -5,7 +5,7 @@ import DrawerMenu from "./DrawerMenu";
 export default function Header() {
   return (
     <header className="sticky top-0 text-gray-600 body-font bg-white z-50">
-      <div className="container mx-auto flex flex-wrap p-5 items-center justify-between">
+      <div className="container mx-auto flex flex-wrap p-6 items-center justify-between md:max-w-5xl">
         <div className="flex items-center">
         <span className="md:hidden"><DrawerMenu/></span>
           <div className="flex items-center">

--- a/app/components/page/DairyRecord/Caluculator.tsx
+++ b/app/components/page/DairyRecord/Caluculator.tsx
@@ -6,6 +6,7 @@ import Datepicker from './DatePicker';
 export default function Caluculator() {
   return (
     <>
+    <div className="flex flex-col w-full max-w-lg">
       <Fieldset legend="日付を選択" className='flex w-full'>
         <div className="felx space-y-4 w-full px-2 mx-auto">
           {/* レシート内容の入力 */}
@@ -18,6 +19,7 @@ export default function Caluculator() {
           <RecordInputForm/>
         </div>
       </Fieldset>
+      </div>
     </>
   )
 }

--- a/app/components/page/DairyRecord/Caluculator.tsx
+++ b/app/components/page/DairyRecord/Caluculator.tsx
@@ -9,13 +9,11 @@ export default function Caluculator() {
     <div className="flex flex-col w-full max-w-lg">
       <Fieldset legend="日付を選択" className='flex w-full'>
         <div className="felx space-y-4 w-full px-2 mx-auto">
-          {/* レシート内容の入力 */}
           <Datepicker/>
         </div>
       </Fieldset>
       <Fieldset legend="レシートから値を入力" className='w-full mt-3'>
         <div className="flex space-y-4 w-full">
-          {/* レシート内容の入力 */}
           <RecordInputForm/>
         </div>
       </Fieldset>

--- a/app/components/page/DairyRecord/Caluculator.tsx
+++ b/app/components/page/DairyRecord/Caluculator.tsx
@@ -1,0 +1,23 @@
+"use client"
+import { Fieldset } from '@mantine/core';
+import RecordInputForm from './RecordInputForm';
+import Datepicker from './DatePicker';
+
+export default function Caluculator() {
+  return (
+    <>
+      <Fieldset legend="日付を選択" className='flex w-full'>
+        <div className="felx space-y-4 w-full px-2 mx-auto">
+          {/* レシート内容の入力 */}
+          <Datepicker/>
+        </div>
+      </Fieldset>
+      <Fieldset legend="レシートから値を入力" className='w-full mt-3'>
+        <div className="flex space-y-4 w-full">
+          {/* レシート内容の入力 */}
+          <RecordInputForm/>
+        </div>
+      </Fieldset>
+    </>
+  )
+}

--- a/app/components/page/DairyRecord/CurrentData.tsx
+++ b/app/components/page/DairyRecord/CurrentData.tsx
@@ -1,5 +1,5 @@
 import useCalculationStore from '@/store/calculationStore';
-import { UserIcon, CurrencyYenIcon, UsersIcon} from "@heroicons/react/24/outline";
+import { UserIcon, CurrencyYenIcon } from "@heroicons/react/24/outline";
 import ShirtIcon from '../../ui/icon/ShirtIcon';
 import CustomersHoverCard from './CustomersHoverCard';
 
@@ -19,7 +19,9 @@ export default function CurrentData() {
             <h2 className="title-font font-medium text-xl text-gray-600 mr-1">
               {count}
             </h2>
-            <CustomersHoverCard />
+            <div className="md:hidden">
+              <CustomersHoverCard />
+            </div>
           </div>
         </div>
   

--- a/app/components/page/DairyRecord/CurrentData.tsx
+++ b/app/components/page/DairyRecord/CurrentData.tsx
@@ -1,7 +1,10 @@
-import { Button, Group } from '@mantine/core';
-import { UserIcon, CurrencyYenIcon, ClipboardDocumentListIcon, UsersIcon} from "@heroicons/react/24/outline";
+import useCalculationStore from '@/store/calculationStore';
+import { UserIcon, CurrencyYenIcon, UsersIcon} from "@heroicons/react/24/outline";
 
 export default function CurrentData() {
+
+  const { totalAmount, totalNumber, customerCount, customers } = useCalculationStore();
+
   return (
     <>
       <div className="flex flex-row justify-center w-full">
@@ -13,7 +16,7 @@ export default function CurrentData() {
           </p>
           <div className="flex flex-row items-center whitespace-nowrap">
             <h2 className="title-font font-medium text-xl text-gray-900">
-              2客
+              {customerCount}客
             </h2>
             <UsersIcon  className="w-5 h-5 font-bold ml-2" />
           </div>
@@ -27,19 +30,19 @@ export default function CurrentData() {
           </p>
           <div className="flex flex-row items-center whitespace-nowrap">
             <h2 className="title-font font-medium text-xl text-gray-900">
-              2点
+              {totalNumber}点
             </h2>
           </div>
         </div>
   
         <div className="flex flex-col justify-center py-2 px-8 border-l border-gray-200">
-          <UserIcon className="w-8 h-8 mx-auto"/>
+          <CurrencyYenIcon className="w-8 h-8 mx-auto"/>
           <p className="flex text-xs mx-auto">
             金額
           </p>
           <div className="flex flex-row items-center whitespace-nowrap">
             <h2 className="title-font font-medium text-xl text-gray-900">
-              ￥2000
+              ￥{totalAmount}
             </h2>
           </div>
         </div>

--- a/app/components/page/DairyRecord/CurrentData.tsx
+++ b/app/components/page/DairyRecord/CurrentData.tsx
@@ -1,9 +1,10 @@
 import useCalculationStore from '@/store/calculationStore';
 import { UserIcon, CurrencyYenIcon, UsersIcon} from "@heroicons/react/24/outline";
 import ShirtIcon from '../../ui/icon/ShirtIcon';
+import CustomersHoverCard from './CustomersHoverCard';
 
 export default function CurrentData() {
-  const { totalAmount, totalNumber, customerCount, customers } = useCalculationStore();
+  const { totalAmount, totalNumber,count} = useCalculationStore();
   
   return (
     <>
@@ -14,11 +15,11 @@ export default function CurrentData() {
           <p className="text-xs mx-auto text-gray-400">
             客数
           </p>
-          <div className="flex flex-row items-center whitespace-nowrap mt-2">
-            <h2 className="title-font font-medium text-xl text-gray-600">
-              {customerCount}
+          <div className="flex flex-row items-center justify-center whitespace-nowrap mt-2 h-10">
+            <h2 className="title-font font-medium text-xl text-gray-600 mr-1">
+              {count}
             </h2>
-            <UsersIcon  className="w-5 h-5 ml-2 text-gray-400" />
+            <CustomersHoverCard />
           </div>
         </div>
   
@@ -27,7 +28,7 @@ export default function CurrentData() {
           <p className="flex text-xs mx-auto text-gray-400">
             点数
           </p>
-          <div className="flex flex-row items-center justify-center whitespace-nowrap mt-2">
+          <div className="flex flex-row items-center justify-center whitespace-nowrap mt-2 h-10">
             <h2 className="title-font font-medium text-xl text-gray-600">
               {totalNumber}
             </h2>
@@ -39,9 +40,9 @@ export default function CurrentData() {
           <p className="flex text-xs mx-auto text-gray-400">
             金額
           </p>
-          <div className="flex flex-row items-center whitespace-nowrap mt-2">
+          <div className="flex flex-row items-center justify-center whitespace-nowrap mt-2 h-10">
             <h2 className="title-font font-medium text-xl text-gray-600">
-              ￥ {totalAmount}
+              {totalAmount}
             </h2>
           </div>
         </div>

--- a/app/components/page/DairyRecord/CurrentData.tsx
+++ b/app/components/page/DairyRecord/CurrentData.tsx
@@ -1,48 +1,47 @@
 import useCalculationStore from '@/store/calculationStore';
 import { UserIcon, CurrencyYenIcon, UsersIcon} from "@heroicons/react/24/outline";
+import ShirtIcon from '../../ui/icon/ShirtIcon';
 
 export default function CurrentData() {
-
   const { totalAmount, totalNumber, customerCount, customers } = useCalculationStore();
-
+  
   return (
     <>
       <div className="flex flex-row justify-center w-full">
 
         <div className="flex flex-col justify-center py-2 px-8">
-          <UserIcon className="w-8 h-8 mx-auto"/>
-          <p className="text-xs mx-auto">
+          <UserIcon className="w-8 h-8 mx-auto text-gray-500"/>
+          <p className="text-xs mx-auto text-gray-400">
             客数
           </p>
-          <div className="flex flex-row items-center whitespace-nowrap">
-            <h2 className="title-font font-medium text-xl text-gray-900">
-              {customerCount}客
+          <div className="flex flex-row items-center whitespace-nowrap mt-2">
+            <h2 className="title-font font-medium text-xl text-gray-600">
+              {customerCount}
             </h2>
-            <UsersIcon  className="w-5 h-5 font-bold ml-2" />
+            <UsersIcon  className="w-5 h-5 ml-2 text-gray-400" />
           </div>
         </div>
-
   
         <div className="flex flex-col justify-center py-2 px-8 border-l border-gray-200">
-          <UserIcon className="w-8 h-8 mx-auto"/>
-          <p className="flex text-xs mx-auto">
+          <ShirtIcon className="w-8 h-8 mx-auto text-gray-500"/>
+          <p className="flex text-xs mx-auto text-gray-400">
             点数
           </p>
-          <div className="flex flex-row items-center whitespace-nowrap">
-            <h2 className="title-font font-medium text-xl text-gray-900">
-              {totalNumber}点
+          <div className="flex flex-row items-center justify-center whitespace-nowrap mt-2">
+            <h2 className="title-font font-medium text-xl text-gray-600">
+              {totalNumber}
             </h2>
           </div>
         </div>
   
         <div className="flex flex-col justify-center py-2 px-8 border-l border-gray-200">
-          <CurrencyYenIcon className="w-8 h-8 mx-auto"/>
-          <p className="flex text-xs mx-auto">
+          <CurrencyYenIcon className="w-8 h-8 mx-auto text-gray-500"/>
+          <p className="flex text-xs mx-auto text-gray-400">
             金額
           </p>
-          <div className="flex flex-row items-center whitespace-nowrap">
-            <h2 className="title-font font-medium text-xl text-gray-900">
-              ￥{totalAmount}
+          <div className="flex flex-row items-center whitespace-nowrap mt-2">
+            <h2 className="title-font font-medium text-xl text-gray-600">
+              ￥ {totalAmount}
             </h2>
           </div>
         </div>

--- a/app/components/page/DairyRecord/CurrentData.tsx
+++ b/app/components/page/DairyRecord/CurrentData.tsx
@@ -1,0 +1,50 @@
+import { Button, Group } from '@mantine/core';
+import { UserIcon, CurrencyYenIcon, ClipboardDocumentListIcon, UsersIcon} from "@heroicons/react/24/outline";
+
+export default function CurrentData() {
+  return (
+    <>
+      <div className="flex flex-row justify-center w-full">
+
+        <div className="flex flex-col justify-center py-2 px-8">
+          <UserIcon className="w-8 h-8 mx-auto"/>
+          <p className="text-xs mx-auto">
+            客数
+          </p>
+          <div className="flex flex-row items-center whitespace-nowrap">
+            <h2 className="title-font font-medium text-xl text-gray-900">
+              2客
+            </h2>
+            <UsersIcon  className="w-5 h-5 font-bold ml-2" />
+          </div>
+        </div>
+
+  
+        <div className="flex flex-col justify-center py-2 px-8 border-l border-gray-200">
+          <UserIcon className="w-8 h-8 mx-auto"/>
+          <p className="flex text-xs mx-auto">
+            点数
+          </p>
+          <div className="flex flex-row items-center whitespace-nowrap">
+            <h2 className="title-font font-medium text-xl text-gray-900">
+              2点
+            </h2>
+          </div>
+        </div>
+  
+        <div className="flex flex-col justify-center py-2 px-8 border-l border-gray-200">
+          <UserIcon className="w-8 h-8 mx-auto"/>
+          <p className="flex text-xs mx-auto">
+            金額
+          </p>
+          <div className="flex flex-row items-center whitespace-nowrap">
+            <h2 className="title-font font-medium text-xl text-gray-900">
+              ￥2000
+            </h2>
+          </div>
+        </div>
+
+      </div>
+    </>
+  )
+}

--- a/app/components/page/DairyRecord/CurrentDate.tsx
+++ b/app/components/page/DairyRecord/CurrentDate.tsx
@@ -1,0 +1,17 @@
+import useCalculationStore from '@/store/calculationStore';
+import dayjs from 'dayjs';
+import { FlagIcon } from "@heroicons/react/24/solid";
+
+export default function CurrentDate() {
+    const { selectedDate } = useCalculationStore();
+
+  // 日付のフォーマットを表示用にする
+  const formattedSelectedDate = dayjs(selectedDate).format("YYYY / MM / DD   ( ddd )");
+
+  return (
+    <div className="flex flex-row justify-center items-center w-full">
+        <FlagIcon className="w-5 h-5 text-gray-500 mr-2"/>
+        { formattedSelectedDate }
+    </div>
+  )
+}

--- a/app/components/page/DairyRecord/CustomersHoverCard.tsx
+++ b/app/components/page/DairyRecord/CustomersHoverCard.tsx
@@ -1,0 +1,23 @@
+import useCalculationStore from '@/store/calculationStore';
+import { HoverCard, Text, Group, Avatar } from '@mantine/core';
+import { UsersIcon } from "@heroicons/react/24/outline";
+
+export default function CustomersHoverCard() {
+  const { customerLabels } = useCalculationStore();
+  return (
+    <Group justify="center">
+      <HoverCard width={280} shadow="md">
+        <HoverCard.Target>
+          <Avatar color="blue" radius="xl">
+            <UsersIcon  className="w-5 h-5" />
+          </Avatar>
+        </HoverCard.Target>
+        <HoverCard.Dropdown>
+          <Text size="xs">
+           {customerLabels}
+          </Text>
+        </HoverCard.Dropdown>
+      </HoverCard>
+    </Group>
+  );
+}

--- a/app/components/page/DairyRecord/CustomersHoverCard.tsx
+++ b/app/components/page/DairyRecord/CustomersHoverCard.tsx
@@ -1,9 +1,8 @@
-import useCalculationStore from '@/store/calculationStore';
 import { HoverCard, Text, Group, Avatar } from '@mantine/core';
 import { UsersIcon } from "@heroicons/react/24/outline";
+import CustomersList from './CustomersList';
 
 export default function CustomersHoverCard() {
-  const { customerLabels } = useCalculationStore();
   return (
     <Group justify="center">
       <HoverCard width={280} shadow="md">
@@ -14,7 +13,7 @@ export default function CustomersHoverCard() {
         </HoverCard.Target>
         <HoverCard.Dropdown>
           <Text size="xs">
-           {customerLabels}
+            <CustomersList/>
           </Text>
         </HoverCard.Dropdown>
       </HoverCard>

--- a/app/components/page/DairyRecord/CustomersList.tsx
+++ b/app/components/page/DairyRecord/CustomersList.tsx
@@ -1,0 +1,47 @@
+import useCalculationStore from '@/store/calculationStore';
+import { List, ThemeIcon, rem } from '@mantine/core';
+import { CheckIcon } from "@heroicons/react/24/outline";
+import { Text } from '@mantine/core';
+import UsersAvatar from './UsersAvatar';
+
+export default function CustomersList() {
+  const { customerLabels } = useCalculationStore();
+
+  const items = customerLabels.split('、').map((label) => (
+    <List.Item key={label}>
+      <Text size="sm" fw={500} component="span">{label}</Text>
+    </List.Item>
+  ));
+
+  return (
+    <div className="flex justify-center items-center w-full">
+
+      {customerLabels.length > 0 ? (
+        <div className="flex flex-row justify-center items-center w-full h-20">
+        <List
+          spacing="xs"
+          style={{ height: '80px', overflowY: 'auto' }}
+          size="xs"
+          center
+          icon={
+            <ThemeIcon color="rgba(137, 197, 250, 1)" size={16} radius="xl">
+              <CheckIcon style={{ width: rem(16), height: rem(16) }} />
+            </ThemeIcon>
+          }
+        >
+          {items}   
+        </List>
+        </div>
+      ) : (
+        <div className="flex flex-row items-center h-20">
+        <UsersAvatar/>
+
+          <span className='ml-2'>: 選択されていません</span>
+
+        </div>
+      )}
+
+    </div>
+
+  )
+}

--- a/app/components/page/DairyRecord/CustomersList.tsx
+++ b/app/components/page/DairyRecord/CustomersList.tsx
@@ -1,47 +1,27 @@
 import useCalculationStore from '@/store/calculationStore';
-import { List, ThemeIcon, rem } from '@mantine/core';
-import { CheckIcon } from "@heroicons/react/24/outline";
-import { Text } from '@mantine/core';
+import { CheckCircleIcon } from "@heroicons/react/24/solid";
 import UsersAvatar from './UsersAvatar';
 
 export default function CustomersList() {
   const { customerLabels } = useCalculationStore();
 
-  const items = customerLabels.split('、').map((label) => (
-    <List.Item key={label}>
-      <Text size="sm" fw={500} component="span">{label}</Text>
-    </List.Item>
-  ));
-
   return (
-    <div className="flex justify-center items-center w-full">
-
+    <div className="flex flex-row justify-center items-center w-fll h-20 px-6">
       {customerLabels.length > 0 ? (
-        <div className="flex flex-row justify-center items-center w-full h-20">
-        <List
-          spacing="xs"
-          style={{ height: '80px', overflowY: 'auto' }}
-          size="xs"
-          center
-          icon={
-            <ThemeIcon color="rgba(137, 197, 250, 1)" size={16} radius="xl">
-              <CheckIcon style={{ width: rem(16), height: rem(16) }} />
-            </ThemeIcon>
-          }
-        >
-          {items}   
-        </List>
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-2 w-full">
+          {customerLabels.split('、').map((label, index) => (
+            <div key={index} className="flex items-center justify-center">
+              <CheckCircleIcon className="w-4 h-4 text-blue-400 mr-1" />
+              <span className="text-sm font-medium">{label}</span>
+            </div>
+          ))}
         </div>
       ) : (
-        <div className="flex flex-row items-center h-20">
-        <UsersAvatar/>
-
+        <>
+          <UsersAvatar/>
           <span className='ml-2'>: 選択されていません</span>
-
-        </div>
+        </>
       )}
-
     </div>
-
   )
 }

--- a/app/components/page/DairyRecord/DatePicker.tsx
+++ b/app/components/page/DairyRecord/DatePicker.tsx
@@ -1,22 +1,29 @@
 "use client"
+import useCalculationStore from '@/store/calculationStore';
 import { DatePickerInput } from '@mantine/dates';
 import { rem } from '@mantine/core';
 import { CalendarIcon } from "@heroicons/react/24/outline";
-import { useState } from 'react';
-import dayjs from 'dayjs';
 
 export default function Datepicker() {
-  const [value, setValue] = useState<Date | null>(null)
+  const { count,setSelectedDate } = useCalculationStore();
+
+  const isDataEntered = count !== 0;
+
   const icon = <CalendarIcon style={{ width: rem(18), height: rem(18) }}/>;
+
+  const handleDateChange = (date: Date | null) => {
+    if (date) {
+      setSelectedDate(date);
+    }
+  };
 
   return (
     <DatePickerInput
       leftSection={icon}
       leftSectionPointerEvents="none"
       size="xs"
-      value={value}
-      onChange={setValue}
-      withAsterisk
+      onChange={handleDateChange}
+      disabled={isDataEntered}
       valueFormat= "YYYY / MM / DD   ( ddd )"
       maxDate={new Date()}
     />

--- a/app/components/page/DairyRecord/DatePicker.tsx
+++ b/app/components/page/DairyRecord/DatePicker.tsx
@@ -5,7 +5,7 @@ import { rem } from '@mantine/core';
 import { CalendarIcon } from "@heroicons/react/24/outline";
 
 export default function Datepicker() {
-  const { count,setSelectedDate } = useCalculationStore();
+  const { count, selectedDate, setSelectedDate } = useCalculationStore();
 
   const isDataEntered = count !== 0;
 
@@ -23,6 +23,7 @@ export default function Datepicker() {
       leftSectionPointerEvents="none"
       size="xs"
       onChange={handleDateChange}
+      value={selectedDate}
       disabled={isDataEntered}
       valueFormat= "YYYY / MM / DD   ( ddd )"
       maxDate={new Date()}

--- a/app/components/page/DairyRecord/DatePicker.tsx
+++ b/app/components/page/DairyRecord/DatePicker.tsx
@@ -1,0 +1,24 @@
+"use client"
+import { DatePickerInput } from '@mantine/dates';
+import { rem } from '@mantine/core';
+import { CalendarIcon } from "@heroicons/react/24/outline";
+import { useState } from 'react';
+import dayjs from 'dayjs';
+
+export default function Datepicker() {
+  const [value, setValue] = useState<Date | null>(null)
+  const icon = <CalendarIcon style={{ width: rem(18), height: rem(18) }}/>;
+
+  return (
+    <DatePickerInput
+      leftSection={icon}
+      leftSectionPointerEvents="none"
+      size="xs"
+      value={value}
+      onChange={setValue}
+      withAsterisk
+      valueFormat= "YYYY / MM / DD   ( ddd )"
+      maxDate={new Date()}
+    />
+  );
+}

--- a/app/components/page/DairyRecord/RecordInputForm.tsx
+++ b/app/components/page/DairyRecord/RecordInputForm.tsx
@@ -1,14 +1,36 @@
 'use client'
-import { NumberInput, Select, Button, Group, Box } from '@mantine/core';
+import useCalculationStore from '@/store/calculationStore';
+import { NumberInput, Select, Button, Group } from '@mantine/core';
 
 export default function RecordInputForm () {
+
+  const { addToTotal, options } = useCalculationStore();
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    // フォームデータの取得
+    const formData = new FormData(event.currentTarget);
+    const amount = parseFloat(formData.get('amount') as string);
+    const number = parseFloat(formData.get('number') as string);
+    const customer = formData.get('customer') as string;
+    
+    addToTotal({ amount, number, customer });
+    console.log(amount)
+    console.log(number)
+    console.log(customer)
+
+
+    // フォームのリセット
+    event.currentTarget.reset();
+  };
 
     return (
         <>
         <div className="flex justify-center items-center w-full">
-        <form onSubmit={() => console.log('hello')} className="w-full mx-auto px-2">
+        <form onSubmit={handleSubmit} className="w-full mx-auto px-2">
         <NumberInput
           label="点数"
+          name="number"
           withAsterisk
           min={0}
           max={30}
@@ -17,6 +39,7 @@ export default function RecordInputForm () {
         />
         <NumberInput
           label="金額"
+          name="amount" 
           withAsterisk
           min={0}
           max={500000}
@@ -29,9 +52,14 @@ export default function RecordInputForm () {
           label="客層"
           withAsterisk
           size="xs"
+          data={options.map((option) => ({
+            value: option.value.toString(),
+            label: option.label,
+          }))}
         />
+
         <Group justify="flex-end" mt="md">
-          <Button>Submit</Button>
+          <Button type="submit">加算する</Button>
         </Group>
       </form>
       </div>

--- a/app/components/page/DairyRecord/RecordInputForm.tsx
+++ b/app/components/page/DairyRecord/RecordInputForm.tsx
@@ -1,68 +1,86 @@
-'use client'
+import { z } from 'zod';
+import { useForm } from '@mantine/form';
+import { zodResolver } from 'mantine-form-zod-resolver';
 import useCalculationStore from '@/store/calculationStore';
-import { NumberInput, Select, Button, Group } from '@mantine/core';
+import { NumberInput, Select, Button } from '@mantine/core';
+import { PlusCircleIcon } from "@heroicons/react/24/solid";
+
+type FormValues = {
+  number: number;
+  amount: number;
+  customer: string;
+};
+
+const schema  = z.object({
+  number: z.number().min(1,  { message: '0より大きな値を入力してください' }),
+  amount: z.number().min(1, { message: '0より大きな値を入力してください' }),
+  customer: z.string().refine(val => val !== '', { message: '客層を選択してください' }),
+});
 
 export default function RecordInputForm () {
-
   const { addToTotal, options } = useCalculationStore();
 
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    // フォームデータの取得
-    const formData = new FormData(event.currentTarget);
-    const amount = parseFloat(formData.get('amount') as string);
-    const number = parseFloat(formData.get('number') as string);
-    const customer = formData.get('customer') as string;
-    
-    addToTotal({ amount, number, customer });
-    console.log(amount)
-    console.log(number)
-    console.log(customer)
+  const form = useForm({
+    initialValues: {
+      number: 0,
+      amount: 0,
+      customer: '',
+    },
+    validate: zodResolver(schema),
+  });
 
-
-    // フォームのリセット
-    event.currentTarget.reset();
+  const handleSubmit = (values: FormValues) => {
+    addToTotal(values);
+    form.reset();
   };
 
-    return (
-        <>
-        <div className="flex justify-center items-center w-full">
-        <form onSubmit={handleSubmit} className="w-full mx-auto px-2">
-        <NumberInput
-          label="点数"
-          name="number"
-          withAsterisk
-          min={0}
-          max={30}
-          suffix="点"
-          size="xs"
-        />
-        <NumberInput
-          label="金額"
-          name="amount" 
-          withAsterisk
-          min={0}
-          max={500000}
-          prefix="￥"
-          thousandSeparator=","
-          size="xs"
-          hideControls
-        />
-        <Select
-          label="客層"
-          withAsterisk
-          size="xs"
-          data={options.map((option) => ({
-            value: option.value.toString(),
-            label: option.label,
-          }))}
-        />
+  return (
+    <>
+      <div className="flex justify-center items-center w-full">
+        <form onSubmit={form.onSubmit(handleSubmit)} className='w-full mx-auto px-2'>
+          <NumberInput
+            {...form.getInputProps('number')}
+            label="点数"
+            name="number"
+            withAsterisk
+            min={0}
+            max={30}
+            suffix="点"
+            size="xs"
+          />
+          <NumberInput
+            {...form.getInputProps('amount')}
+            label="金額"
+            name="amount" 
+            withAsterisk
+            min={0}
+            max={500000}
+            prefix="￥"
+            thousandSeparator=","
+            size="xs"
+            hideControls
+          />
+          <Select
+            key={form.values.customer}
+            {...form.getInputProps('customer')}
+            label="客層"
+            name="customer" 
+            withAsterisk
+            size="xs"
+            data={options.map((option) => ({
+              value: option.value.toString(),
+              label: option.label,
+            }))}
+          />
 
-        <Group justify="flex-end" mt="md">
-          <Button type="submit">加算する</Button>
-        </Group>
-      </form>
+          <div className="flex justify-end mt-4">
+            <Button type="submit" variant="outline" color="gray" size="xs">
+              加算する
+              <PlusCircleIcon className="w-5 h-5 ml-1 text-blue-400" />
+            </Button>
+          </div>
+        </form>
       </div>
-        </>
-    )
+    </>
+  )
 }

--- a/app/components/page/DairyRecord/RecordInputForm.tsx
+++ b/app/components/page/DairyRecord/RecordInputForm.tsx
@@ -1,0 +1,40 @@
+'use client'
+import { NumberInput, Select, Button, Group, Box } from '@mantine/core';
+
+export default function RecordInputForm () {
+
+    return (
+        <>
+        <div className="flex justify-center items-center w-full">
+        <form onSubmit={() => console.log('hello')} className="w-full mx-auto px-2">
+        <NumberInput
+          label="点数"
+          withAsterisk
+          min={0}
+          max={30}
+          suffix="点"
+          size="xs"
+        />
+        <NumberInput
+          label="金額"
+          withAsterisk
+          min={0}
+          max={500000}
+          prefix="￥"
+          thousandSeparator=","
+          size="xs"
+          hideControls
+        />
+        <Select
+          label="客層"
+          withAsterisk
+          size="xs"
+        />
+        <Group justify="flex-end" mt="md">
+          <Button>Submit</Button>
+        </Group>
+      </form>
+      </div>
+        </>
+    )
+}

--- a/app/components/page/DairyRecord/Submit.tsx
+++ b/app/components/page/DairyRecord/Submit.tsx
@@ -1,0 +1,21 @@
+"use client"
+import { Fieldset } from '@mantine/core';
+import CurrentData from './CurrentData';
+import { Button, Group } from '@mantine/core';
+
+export default function Submit() {
+  return (
+    <>
+    <Fieldset legend="現在入力されている合計" className='w-full mt-3 max-w-lg' style={{ overflowX: 'auto' }}>
+      <div className="flex flex-col space-y-4 w-full">
+        <CurrentData/>
+
+        <Group mt="md" justify="flex-end">
+          <Button>Submit</Button>
+          <Button>Submit</Button>
+      </Group>
+      </div>
+    </Fieldset>
+  </>
+  )
+}

--- a/app/components/page/DairyRecord/Submit.tsx
+++ b/app/components/page/DairyRecord/Submit.tsx
@@ -8,7 +8,7 @@ import CurrentDate from './CurrentDate';
 import CustomersList from './CustomersList';
 
 export default function Submit() {
-  const { clearData } = useCalculationStore();
+  const { clearData, submitData } = useCalculationStore();
 
   return (
     <>
@@ -24,7 +24,7 @@ export default function Submit() {
 
           <div className="flex justify-end mt-4 gap-3">
             <ClearButton onClick={clearData}/>
-            <SubmitButton/>
+            <SubmitButton onClick={submitData}/>
           </div>
         </div>
       </Fieldset>

--- a/app/components/page/DairyRecord/Submit.tsx
+++ b/app/components/page/DairyRecord/Submit.tsx
@@ -1,4 +1,5 @@
 "use client"
+import useCalculationStore from '@/store/calculationStore';
 import { Fieldset } from '@mantine/core';
 import CurrentData from './CurrentData';
 import ClearButton from '../../ui/ClearButton';
@@ -6,6 +7,8 @@ import SubmitButton from '../../ui/SubmitButton';
 import CurrentDate from './CurrentDate';
 
 export default function Submit() {
+  const { clearData } = useCalculationStore();
+
   return (
     <>
     <Fieldset legend="現在入力されている合計" className='w-full mt-3 max-w-lg' style={{ overflowX: 'auto' }}>
@@ -13,7 +16,7 @@ export default function Submit() {
         <CurrentDate/>
         <CurrentData/>
         <div className="flex justify-end mt-4 gap-3">
-          <ClearButton />
+          <ClearButton onClick={clearData}/>
           <SubmitButton/>
         </div>
       </div>

--- a/app/components/page/DairyRecord/Submit.tsx
+++ b/app/components/page/DairyRecord/Submit.tsx
@@ -1,7 +1,8 @@
 "use client"
 import { Fieldset } from '@mantine/core';
 import CurrentData from './CurrentData';
-import { Button, Group } from '@mantine/core';
+import ClearButton from '../../ui/ClearButton';
+import SubmitButton from '../../ui/SubmitButton';
 
 export default function Submit() {
   return (
@@ -9,11 +10,10 @@ export default function Submit() {
     <Fieldset legend="現在入力されている合計" className='w-full mt-3 max-w-lg' style={{ overflowX: 'auto' }}>
       <div className="flex flex-col space-y-4 w-full">
         <CurrentData/>
-
-        <Group mt="md" justify="flex-end">
-          <Button>Submit</Button>
-          <Button>Submit</Button>
-      </Group>
+        <div className="flex justify-end mt-4 gap-3">
+          <ClearButton />
+          <SubmitButton/>
+        </div>
       </div>
     </Fieldset>
   </>

--- a/app/components/page/DairyRecord/Submit.tsx
+++ b/app/components/page/DairyRecord/Submit.tsx
@@ -3,12 +3,14 @@ import { Fieldset } from '@mantine/core';
 import CurrentData from './CurrentData';
 import ClearButton from '../../ui/ClearButton';
 import SubmitButton from '../../ui/SubmitButton';
+import CurrentDate from './CurrentDate';
 
 export default function Submit() {
   return (
     <>
     <Fieldset legend="現在入力されている合計" className='w-full mt-3 max-w-lg' style={{ overflowX: 'auto' }}>
       <div className="flex flex-col space-y-4 w-full">
+        <CurrentDate/>
         <CurrentData/>
         <div className="flex justify-end mt-4 gap-3">
           <ClearButton />

--- a/app/components/page/DairyRecord/Submit.tsx
+++ b/app/components/page/DairyRecord/Submit.tsx
@@ -12,7 +12,7 @@ export default function Submit() {
 
   return (
     <>
-      <Fieldset legend="現在入力されている合計" className='w-full mt-3 max-w-lg' style={{ overflowX: 'auto' }}>
+      <Fieldset legend="現在の合計" className='w-full mt-3 max-w-lg' style={{ overflowX: 'auto' }}>
         <div className="flex flex-col space-y-4 w-full">
           <CurrentDate/>
           <CurrentData/>

--- a/app/components/page/DairyRecord/Submit.tsx
+++ b/app/components/page/DairyRecord/Submit.tsx
@@ -5,22 +5,29 @@ import CurrentData from './CurrentData';
 import ClearButton from '../../ui/ClearButton';
 import SubmitButton from '../../ui/SubmitButton';
 import CurrentDate from './CurrentDate';
+import CustomersList from './CustomersList';
 
 export default function Submit() {
   const { clearData } = useCalculationStore();
 
   return (
     <>
-    <Fieldset legend="現在入力されている合計" className='w-full mt-3 max-w-lg' style={{ overflowX: 'auto' }}>
-      <div className="flex flex-col space-y-4 w-full">
-        <CurrentDate/>
-        <CurrentData/>
-        <div className="flex justify-end mt-4 gap-3">
-          <ClearButton onClick={clearData}/>
-          <SubmitButton/>
+      <Fieldset legend="現在入力されている合計" className='w-full mt-3 max-w-lg' style={{ overflowX: 'auto' }}>
+        <div className="flex flex-col space-y-4 w-full">
+          <CurrentDate/>
+          <CurrentData/>
+
+          {/* md以上のみ表示 */}
+          <div className="hidden md:block"> 
+            <CustomersList/>
+          </div>
+
+          <div className="flex justify-end mt-4 gap-3">
+            <ClearButton onClick={clearData}/>
+            <SubmitButton/>
+          </div>
         </div>
-      </div>
-    </Fieldset>
-  </>
+      </Fieldset>
+    </>
   )
 }

--- a/app/components/page/DairyRecord/Submit.tsx
+++ b/app/components/page/DairyRecord/Submit.tsx
@@ -1,14 +1,46 @@
 "use client"
+import { useRouter } from 'next/navigation'
+import axios from 'axios'
 import useCalculationStore from '@/store/calculationStore';
-import { Fieldset } from '@mantine/core';
 import CurrentData from './CurrentData';
 import ClearButton from '../../ui/ClearButton';
 import SubmitButton from '../../ui/SubmitButton';
 import CurrentDate from './CurrentDate';
 import CustomersList from './CustomersList';
+import { Fieldset } from '@mantine/core';
+import { showErrorNotification } from '@/utils/notifications';
+import { showSuccessNotification } from '@/utils/notifications';
 
 export default function Submit() {
   const { clearData, submitData } = useCalculationStore();
+  const router = useRouter()
+
+  const handleSubmit = async () => {
+    const { dairy_record, customer_counts } = submitData();
+
+    if (Object.keys(customer_counts).length === 0) {
+      const isConfirmed = confirm("売上が0です。本当に登録しますか？");
+      if (!isConfirmed) {
+        return;
+      }
+    }
+    
+    try {
+      const response = await axios.post(`/api/dairyrecord`, { 
+        dairy_record,
+        customer_counts
+      });
+
+      // response.dataから日付を取得
+      const date = response.data.dairy_record.date;
+      showSuccessNotification(`${date}の売上を登録しました`);
+      clearData();
+      router.push('/dashboard'); 
+    } catch (error) {
+      showErrorNotification('送信に失敗しました。もう一度お試しください。');
+      console.error("Failed to fetch", error);
+    }
+  };
 
   return (
     <>
@@ -24,7 +56,7 @@ export default function Submit() {
 
           <div className="flex justify-end mt-4 gap-3">
             <ClearButton onClick={clearData}/>
-            <SubmitButton onClick={submitData}/>
+            <SubmitButton onClick={handleSubmit}/>
           </div>
         </div>
       </Fieldset>

--- a/app/components/page/DairyRecord/UsersAvatar.tsx
+++ b/app/components/page/DairyRecord/UsersAvatar.tsx
@@ -1,0 +1,10 @@
+import { Avatar } from '@mantine/core';
+import { UsersIcon } from "@heroicons/react/24/outline";
+
+export default function UsersAvatar() {
+  return (
+    <Avatar color="blue" radius="xl">
+      <UsersIcon  className="w-5 h-5" />
+    </Avatar>
+  )
+}

--- a/app/components/ui/ClearButton.tsx
+++ b/app/components/ui/ClearButton.tsx
@@ -1,9 +1,13 @@
 import { Button } from '@mantine/core';
 import { XCircleIcon } from "@heroicons/react/24/solid";
 
-export default function ClearButton() {
+type ClearButtonProps = {
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+};
+
+export default function ClearButton({ onClick }: ClearButtonProps) {
   return (
-    <Button type="submit" variant="outline" color="gray" size="xs">
+    <Button type="button" variant="outline" color="gray" size="xs" onClick={onClick}>
       クリア
       <XCircleIcon className="w-5 h-5 ml-1 text-red-400" />
     </Button>

--- a/app/components/ui/ClearButton.tsx
+++ b/app/components/ui/ClearButton.tsx
@@ -1,0 +1,11 @@
+import { Button } from '@mantine/core';
+import { XCircleIcon } from "@heroicons/react/24/solid";
+
+export default function ClearButton() {
+  return (
+    <Button type="submit" variant="outline" color="gray" size="xs">
+      クリア
+      <XCircleIcon className="w-5 h-5 ml-1 text-red-400" />
+    </Button>
+  )
+}

--- a/app/components/ui/SubmitButton.tsx
+++ b/app/components/ui/SubmitButton.tsx
@@ -1,0 +1,11 @@
+import { Button } from '@mantine/core';
+import { PaperAirplaneIcon } from "@heroicons/react/24/solid";
+
+export default function SubmitButton() {
+  return (
+    <Button type="submit" variant="outline" color="gray" size="xs">
+      登録
+      <PaperAirplaneIcon className="w-5 h-5 ml-1 text-blue-400" />
+    </Button>
+  )
+}

--- a/app/components/ui/SubmitButton.tsx
+++ b/app/components/ui/SubmitButton.tsx
@@ -1,9 +1,13 @@
 import { Button } from '@mantine/core';
 import { PaperAirplaneIcon } from "@heroicons/react/24/solid";
 
-export default function SubmitButton() {
+type SubmitButtonProps = {
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+};
+
+export default function SubmitButton({ onClick }: SubmitButtonProps) {
   return (
-    <Button type="submit" variant="outline" color="gray" size="xs">
+    <Button type="submit" variant="outline" color="gray" size="xs" onClick={onClick}>
       登録
       <PaperAirplaneIcon className="w-5 h-5 ml-1 text-blue-400" />
     </Button>

--- a/app/components/ui/icon/ShirtIcon.tsx
+++ b/app/components/ui/icon/ShirtIcon.tsx
@@ -1,0 +1,12 @@
+type IconProps = {
+  className?: string;
+};
+
+export default function ShirtIcon({ className }: IconProps ) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" className={`icon icon-tabler icon-tabler-shirt ${className}`} width="44" height="44" viewBox="0 0 24 24" strokeWidth="1.5" stroke="#6b7280" fill="none" strokeLinecap="round" strokeLinejoin="round">
+      <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+      <path d="M15 4l6 2v5h-3v8a1 1 0 0 1 -1 1h-10a1 1 0 0 1 -1 -1v-8h-3v-5l6 -2a3 3 0 0 0 6 0" />
+    </svg>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,13 @@
         "@mantine/notifications": "^7.3.0",
         "axios": "^1.6.2",
         "dayjs": "^1.11.10",
+        "mantine-form-zod-resolver": "^1.0.0",
         "next": "14.0.3",
         "next-auth": "^4.24.5",
         "react": "^18",
         "react-dom": "^18",
         "sharp": "^0.33.0",
+        "zod": "^3.22.4",
         "zustand": "^4.4.7"
       },
       "devDependencies": {
@@ -3578,6 +3580,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/mantine-form-zod-resolver": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mantine-form-zod-resolver/-/mantine-form-zod-resolver-1.0.0.tgz",
+      "integrity": "sha512-7P7UL/4XHpjRbKVb0M6YqtJ88XhR/ANrze3zoAWxIZPqqIOEnTNAW963ezn6szEmwD3i/r/SUD/e8LPdEv7zqA==",
+      "engines": {
+        "node": ">=16.6.0"
+      },
+      "peerDependencies": {
+        "@mantine/form": ">=7.0.0",
+        "zod": ">=3.0.0"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5485,6 +5499,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -17,11 +17,13 @@
     "@mantine/notifications": "^7.3.0",
     "axios": "^1.6.2",
     "dayjs": "^1.11.10",
+    "mantine-form-zod-resolver": "^1.0.0",
     "next": "14.0.3",
     "next-auth": "^4.24.5",
     "react": "^18",
     "react-dom": "^18",
     "sharp": "^0.33.0",
+    "zod": "^3.22.4",
     "zustand": "^4.4.7"
   },
   "devDependencies": {

--- a/providers/MantineProvider.tsx
+++ b/providers/MantineProvider.tsx
@@ -4,6 +4,7 @@ import { Notifications } from '@mantine/notifications';
 
 import '@mantine/core/styles.css';
 import '@mantine/notifications/styles.css';
+import '@mantine/dates/styles.css';
 
 type Props = {
   children?: React.ReactNode;

--- a/store/calculationStore.ts
+++ b/store/calculationStore.ts
@@ -10,11 +10,17 @@ type Option = {
 type CalculationState = {
   totalAmount: number;
   totalNumber: number;
-  customerCount: number;
+  count: number;
   customers: string[];
   options: Option[];
+  customerTypeCounts: Record<string, number>;
+  customerLabels: string;
   addToTotal: (params: AddToTotalParams) => void;
+  calculateCustomerCounts: (customers: string[]) => Record<string, number>;
+  generateCustomerLabels: (customerTypeCounts: Record<string, number>) => string;
 };
+
+type CustomerCounts = Record<string, number>;
 
 type AddToTotalParams = {
   amount: number;
@@ -25,8 +31,10 @@ type AddToTotalParams = {
 const useCalculationStore = create<CalculationState>((set, get) => ({
   totalAmount: 0,
   totalNumber: 0,
-  customerCount: 0,
-  customers: [],
+  count: 0, // 客数カウンター
+  customerTypeCounts: {}, // 各顧客タイプごとの選択回数 { '1': 2, '2': 1 } 
+  customers: [], // 選択された客層 ['1', '2', '1'] 
+  customerLabels: '', // 表示用に変換 "主婦: 2、 OL: 1"
   selectedDate: new Date(),
   options: [
     { value: 1, label: "主婦" },
@@ -42,12 +50,34 @@ const useCalculationStore = create<CalculationState>((set, get) => ({
 
   // 加算アクション
   addToTotal: ({ amount, number, customer }: AddToTotalParams) => {
-    set((state) => ({
-      totalAmount: state.totalAmount + Number(amount),
-      totalNumber: state.totalNumber + Number(number),
-      customers: [...state.customers, customer],
-      customerCount: state.customerCount+ 1
-    }));
+    set((state) => {
+      const newCustomers = [...state.customers, customer];
+      const newCustomerTypeCounts = get().calculateCustomerCounts(newCustomers); // 集計関数を呼び出し
+      const newCustomerLabels = get().generateCustomerLabels(newCustomerTypeCounts); // ラベル付き形式を生成
+      return {
+        totalAmount: state.totalAmount + Number(amount),
+        totalNumber: state.totalNumber + Number(number),
+        count: state.count + 1, // 顧客数をカウント
+        customers: newCustomers,
+        customerTypeCounts: newCustomerTypeCounts,
+        customerLabels: newCustomerLabels, // 更新されたラベル付き形式をセット
+      };
+    });
+  },
+  // customers配列を集計する関数
+  calculateCustomerCounts(customers: string[]): CustomerCounts {
+    return customers.reduce((acc: CustomerCounts, cur: string) => {
+      acc[cur] = (acc[cur] || 0) + 1;
+      return acc;
+    }, {} as CustomerCounts);
+  },
+  // 集計した結果をラベルで表示する関数
+  generateCustomerLabels(customerTypeCounts) {
+    const options = get().options; // 現在のオプションを取得
+    return Object.entries(customerTypeCounts).map(([key, value]) => {
+      const label = options.find(option => option.value.toString() === key)?.label || key;
+      return `${label}: ${value}`;
+    }).join('、 ');
   },
 }));
 

--- a/store/calculationStore.ts
+++ b/store/calculationStore.ts
@@ -15,9 +15,12 @@ type CalculationState = {
   options: Option[];
   customerTypeCounts: Record<string, number>;
   customerLabels: string;
+  selectedDate: Date;
+  setSelectedDate: (date: Date) => void;
   addToTotal: (params: AddToTotalParams) => void;
   calculateCustomerCounts: (customers: string[]) => Record<string, number>;
   generateCustomerLabels: (customerTypeCounts: Record<string, number>) => string;
+
 };
 
 type CustomerCounts = Record<string, number>;
@@ -48,6 +51,10 @@ const useCalculationStore = create<CalculationState>((set, get) => ({
     { value: 9, label: "その他" },
   ],
 
+  // 日付の更新
+  setSelectedDate: (date: Date) => {
+    set({ selectedDate: date });
+  },
   // 加算アクション
   addToTotal: ({ amount, number, customer }: AddToTotalParams) => {
     set((state) => {

--- a/store/calculationStore.ts
+++ b/store/calculationStore.ts
@@ -18,6 +18,7 @@ type CalculationState = {
   selectedDate: Date;
   setSelectedDate: (date: Date) => void;
   addToTotal: (params: AddToTotalParams) => void;
+  submitData: () => Promise<void>;
   clearData: () => void;
   calculateCustomerCounts: (customers: string[]) => Record<string, number>;
   generateCustomerLabels: (customerTypeCounts: Record<string, number>) => string;
@@ -43,12 +44,12 @@ const useCalculationStore = create<CalculationState>((set, get) => ({
   options: [
     { value: 1, label: "主婦" },
     { value: 2, label: "OL" },
-    { value: 3, label: "若ママ" },
-    { value: 4, label: "マダム" },
+    { value: 3, label: "~30代" },
+    { value: 4, label: "~40代" },
     { value: 5, label: "アッパー" },
     { value: 6, label: "学生" },
-    { value: 7, label: "観光客" },
-    { value: 8, label: "ギフト" },
+    { value: 7, label: "ギフト" },
+    { value: 8, label: "顧客" },
     { value: 9, label: "その他" },
   ],
 
@@ -75,6 +76,27 @@ const useCalculationStore = create<CalculationState>((set, get) => ({
 
   // クリアアクション
   clearData: () => set({ totalAmount: 0, totalNumber: 0, count: 0, customers: [], selectedDate: new Date(), customerLabels: ''}),
+
+  // 送信アクション
+  submitData: async () => {
+    const { totalAmount, totalNumber, count, customers, selectedDate } = get();
+    const formattedDate = dayjs(selectedDate).format('YYYY-MM-DD');
+    const dairy_record = {
+      total_amount: totalAmount,
+      total_number: totalNumber,
+      count,
+      date: formattedDate,
+      customers: customers
+    };
+    // ... 送信ロジック ...
+    try {
+      console.log("APIルートに送信する:",dairy_record)
+      const response = await axios.post(`/api/dairyrecord`, { dairy_record });
+      console.log(response.data);
+    } catch (error) {
+      console.error("Failed to fetch", error);
+    }
+  },
 
   // customers配列を集計
   calculateCustomerCounts(customers: string[]): CustomerCounts {

--- a/store/calculationStore.ts
+++ b/store/calculationStore.ts
@@ -74,7 +74,7 @@ const useCalculationStore = create<CalculationState>((set, get) => ({
   },
 
   // クリアアクション
-  clearData: () => set({ totalAmount: 0, totalNumber: 0, count: 0, customers: [], selectedDate: new Date() }),
+  clearData: () => set({ totalAmount: 0, totalNumber: 0, count: 0, customers: [], selectedDate: new Date(), customerLabels: ''}),
 
   // customers配列を集計
   calculateCustomerCounts(customers: string[]): CustomerCounts {

--- a/store/calculationStore.ts
+++ b/store/calculationStore.ts
@@ -18,6 +18,7 @@ type CalculationState = {
   selectedDate: Date;
   setSelectedDate: (date: Date) => void;
   addToTotal: (params: AddToTotalParams) => void;
+  clearData: () => void;
   calculateCustomerCounts: (customers: string[]) => Record<string, number>;
   generateCustomerLabels: (customerTypeCounts: Record<string, number>) => string;
 
@@ -71,14 +72,19 @@ const useCalculationStore = create<CalculationState>((set, get) => ({
       };
     });
   },
-  // customers配列を集計する関数
+
+  // クリアアクション
+  clearData: () => set({ totalAmount: 0, totalNumber: 0, count: 0, customers: [], selectedDate: new Date() }),
+
+  // customers配列を集計
   calculateCustomerCounts(customers: string[]): CustomerCounts {
     return customers.reduce((acc: CustomerCounts, cur: string) => {
       acc[cur] = (acc[cur] || 0) + 1;
       return acc;
     }, {} as CustomerCounts);
   },
-  // 集計した結果をラベルで表示する関数
+
+  // 集計した結果をラベル表示に変換
   generateCustomerLabels(customerTypeCounts) {
     const options = get().options; // 現在のオプションを取得
     return Object.entries(customerTypeCounts).map(([key, value]) => {

--- a/store/calculationStore.ts
+++ b/store/calculationStore.ts
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 import axios from 'axios'
 import dayjs from 'dayjs';
 

--- a/store/calculationStore.ts
+++ b/store/calculationStore.ts
@@ -1,12 +1,27 @@
 import { create } from 'zustand';
-import axios from 'axios'
 import dayjs from 'dayjs';
-import { showErrorNotification } from '@/utils/notifications';
-import { showSuccessNotification } from '@/utils/notifications';
 
 type Option = {
   value: number;
   label: string;
+};
+
+type CustomerCounts = Record<string, number>;
+
+type AddToTotalParams = {
+  amount: number;
+  number: number;
+  customer: string;
+};
+
+type SubmitDataType = {
+  dairy_record: {
+    total_amount: number;
+    total_number: number;
+    count: number;
+    date: string;
+  };
+  customer_counts: Record<string, number>;
 };
 
 type CalculationState = {
@@ -20,18 +35,10 @@ type CalculationState = {
   selectedDate: Date;
   setSelectedDate: (date: Date) => void;
   addToTotal: (params: AddToTotalParams) => void;
-  submitData: () => Promise<void>;
+  submitData: () => SubmitDataType;
   clearData: () => void;
   calculateCustomerCounts: (customers: string[]) => Record<string, number>;
   generateCustomerLabels: (customerTypeCounts: Record<string, number>) => string;
-};
-
-type CustomerCounts = Record<string, number>;
-
-type AddToTotalParams = {
-  amount: number;
-  number: number;
-  customer: string;
 };
 
 const useCalculationStore = create<CalculationState>((set, get) => ({
@@ -79,7 +86,7 @@ const useCalculationStore = create<CalculationState>((set, get) => ({
   clearData: () => set({ totalAmount: 0, totalNumber: 0, count: 0, customers: [], selectedDate: new Date(), customerLabels: ''}),
 
   // 送信アクション
-  submitData: async () => {
+  submitData: () => {
     const { totalAmount, totalNumber, count, customerTypeCounts, selectedDate } = get();
     const formattedDate = dayjs(selectedDate).format('YYYY-MM-DD');
     const dairy_record = {
@@ -89,20 +96,8 @@ const useCalculationStore = create<CalculationState>((set, get) => ({
       date: formattedDate,
     };
     const customer_counts = customerTypeCounts;
-    // ... 送信ロジック ...
-    try {
-      const response = await axios.post(`/api/dairyrecord`, { 
-        dairy_record,
-        customer_counts
-      });
 
-      // response.dataから日付を取得
-      const date = response.data.dairy_record.date;
-      showSuccessNotification(`${date}の売上を登録しました`);
-    } catch (error) {
-      showErrorNotification('送信に失敗しました。もう一度お試しください。');
-      console.error("Failed to fetch", error);
-    }
+    return { dairy_record, customer_counts };
   },
 
   // customers配列を集計

--- a/store/calculationStore.ts
+++ b/store/calculationStore.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand';
 import axios from 'axios'
 import dayjs from 'dayjs';
+import { showErrorNotification } from '@/utils/notifications';
+import { showSuccessNotification } from '@/utils/notifications';
 
 type Option = {
   value: number;
@@ -93,8 +95,12 @@ const useCalculationStore = create<CalculationState>((set, get) => ({
         dairy_record,
         customer_counts
       });
-      console.log(response.data);
+
+      // response.dataから日付を取得
+      const date = response.data.dairy_record.date;
+      showSuccessNotification(`${date}の売上を登録しました`);
     } catch (error) {
+      showErrorNotification('送信に失敗しました。もう一度お試しください。');
       console.error("Failed to fetch", error);
     }
   },

--- a/store/calculationStore.ts
+++ b/store/calculationStore.ts
@@ -22,7 +22,6 @@ type CalculationState = {
   clearData: () => void;
   calculateCustomerCounts: (customers: string[]) => Record<string, number>;
   generateCustomerLabels: (customerTypeCounts: Record<string, number>) => string;
-
 };
 
 type CustomerCounts = Record<string, number>;
@@ -79,19 +78,21 @@ const useCalculationStore = create<CalculationState>((set, get) => ({
 
   // 送信アクション
   submitData: async () => {
-    const { totalAmount, totalNumber, count, customers, selectedDate } = get();
+    const { totalAmount, totalNumber, count, customerTypeCounts, selectedDate } = get();
     const formattedDate = dayjs(selectedDate).format('YYYY-MM-DD');
     const dairy_record = {
       total_amount: totalAmount,
       total_number: totalNumber,
       count,
       date: formattedDate,
-      customers: customers
     };
+    const customer_counts = customerTypeCounts;
     // ... 送信ロジック ...
     try {
-      console.log("APIルートに送信する:",dairy_record)
-      const response = await axios.post(`/api/dairyrecord`, { dairy_record });
+      const response = await axios.post(`/api/dairyrecord`, { 
+        dairy_record,
+        customer_counts
+      });
       console.log(response.data);
     } catch (error) {
       console.error("Failed to fetch", error);

--- a/store/calculationStore.ts
+++ b/store/calculationStore.ts
@@ -1,0 +1,54 @@
+import create from 'zustand';
+import axios from 'axios'
+import dayjs from 'dayjs';
+
+type Option = {
+  value: number;
+  label: string;
+};
+
+type CalculationState = {
+  totalAmount: number;
+  totalNumber: number;
+  customerCount: number;
+  customers: string[];
+  options: Option[];
+  addToTotal: (params: AddToTotalParams) => void;
+};
+
+type AddToTotalParams = {
+  amount: number;
+  number: number;
+  customer: string;
+};
+
+const useCalculationStore = create<CalculationState>((set, get) => ({
+  totalAmount: 0,
+  totalNumber: 0,
+  customerCount: 0,
+  customers: [],
+  selectedDate: new Date(),
+  options: [
+    { value: 1, label: "主婦" },
+    { value: 2, label: "OL" },
+    { value: 3, label: "若ママ" },
+    { value: 4, label: "マダム" },
+    { value: 5, label: "アッパー" },
+    { value: 6, label: "学生" },
+    { value: 7, label: "観光客" },
+    { value: 8, label: "ギフト" },
+    { value: 9, label: "その他" },
+  ],
+
+  // 加算アクション
+  addToTotal: ({ amount, number, customer }: AddToTotalParams) => {
+    set((state) => ({
+      totalAmount: state.totalAmount + Number(amount),
+      totalNumber: state.totalNumber + Number(number),
+      customers: [...state.customers, customer],
+      customerCount: state.customerCount+ 1
+    }));
+  },
+}));
+
+export default useCalculationStore;

--- a/utils/notifications.ts
+++ b/utils/notifications.ts
@@ -1,0 +1,15 @@
+"use client"
+import { showNotification } from '@mantine/notifications';
+
+export function showErrorNotification(message: string) {
+  showNotification({
+    message,
+    color: 'red',
+  });
+}
+
+export function showSuccessNotification(message: string) {
+  showNotification({
+    message,
+  });
+}


### PR DESCRIPTION
## 概要

売上登録機能の実装。
ユーザーは日付を選択→【入力フォームに各値を入力→加算ボタン】×N回 →送信ボタンの操作順で売上を登録できる。
issue: #4  

## 変更点

- dairyrecordページの作成
  - 入力エリア（Datepicker＋入力フォーム＋加算ボタン）
  - 送信エリア（現在加算中の値を表示するエリア＋送信ボタン＋クリアボタン）
- ストアの作成
各プロパティのトータルの値, トータルの値の更新処理, クリア処理等の管理
- APIroute作成
送信ボタン→APIルートを通してバックエンドへ送信,エラーハンドリングを行う。
ここで送信データにuser_idを紐づける。

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0

- バックエンドとのデータの受け渡しを確認
登録成功時...成功のNotificationとダッシュボードへのリダイレクトを確認
登録失敗時...失敗のNotificationを表示
user_idや不要なエラーメッセージがクライアントに露出していないことを確認（サーバーログでのみ確認可能）

- 入力フォーム
加算途中に日付が変更できないことを確認
zod, useFormでのバリデーションが機能することを確認
値0で送信ボタン押下時、confirmが表示されることを確認

## 影響範囲
- /dashboard
- /dairyrecord

## チェックリスト
- [x] レスポンシブ対応


## コメント
選択フォームの選択肢（option）をバックエンドから取得するように修正する。