### PR TITLE
Dashboard #5

### DIFF
--- a/app/(authenticated)/dashboard/page.tsx
+++ b/app/(authenticated)/dashboard/page.tsx
@@ -1,8 +1,20 @@
+"use client"
+import Calender from "@/app/components/page/DashBoard/Calendar";
+import ThisWeek from "@/app/components/page/DashBoard/ThisWeek";
+import { useFetchData } from "@/lib/useFetchData";
+
 export default function Dashboard() {
+  useFetchData();
+  
   return (
     <>
-    <div className="flex justify-center items-center">
-      <p>ダッシュボードです</p>
+    <div className="flex flex-col md:flex-row justify-center items-center mx-auto p-6 z-0 md:gap-x-6 max-w-5xl my-10">
+      <div className="p-7 shadow-md">
+        <ThisWeek/>
+      </div>
+      <div className="bg-white p-7 shadow-md">
+        <Calender/>
+      </div>
     </div>
     </>
   )

--- a/app/api/salesrecord/route.ts
+++ b/app/api/salesrecord/route.ts
@@ -1,0 +1,43 @@
+import axios from 'axios';
+import { getServerSession } from "next-auth/next"
+import { options } from '@/lib/options';
+
+export async function GET()  {
+
+  const session = await getServerSession(options);
+    
+  if (!session) {
+    return new Response(JSON.stringify({ error: '認証が必要です' }), {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  const railsUserId = session.user.railsId;
+  const apiUrl = process.env.RAILS_API_URL
+
+  try {
+    const response = await axios.get(`${apiUrl}/dairy_records`, {
+      headers: {
+        'user': `${railsUserId}`,
+        'Content-Type': 'application/json',
+      },
+    });
+    return new Response(JSON.stringify(response.data), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    return new Response(JSON.stringify({ error:'予期せぬエラーが発生しました' }), {
+      status: 500,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+}

--- a/app/components/page/DairyRecord/CurrentDate.tsx
+++ b/app/components/page/DairyRecord/CurrentDate.tsx
@@ -1,12 +1,11 @@
 import useCalculationStore from '@/store/calculationStore';
-import dayjs from 'dayjs';
 import { FlagIcon } from "@heroicons/react/24/solid";
+import { formatDateLayout } from '@/utils/dateUtils';
 
 export default function CurrentDate() {
-    const { selectedDate } = useCalculationStore();
+  const { selectedDate } = useCalculationStore();
 
-  // 日付のフォーマットを表示用にする
-  const formattedSelectedDate = dayjs(selectedDate).format("YYYY / MM / DD   ( ddd )");
+  const formattedSelectedDate = formatDateLayout(selectedDate);
 
   return (
     <div className="flex flex-row justify-center items-center w-full">

--- a/app/components/page/DairyRecord/DatePicker.tsx
+++ b/app/components/page/DairyRecord/DatePicker.tsx
@@ -1,13 +1,21 @@
 "use client"
 import useCalculationStore from '@/store/calculationStore';
+import useDashboardStore from '@/store/dashboardStore';
 import { DatePickerInput } from '@mantine/dates';
 import { rem } from '@mantine/core';
 import { CalendarIcon } from "@heroicons/react/24/outline";
+import { formatDate } from '@/utils/dateUtils';
 
 export default function Datepicker() {
   const { count, selectedDate, setSelectedDate } = useCalculationStore();
+  const { salesDates } = useDashboardStore((state) => ({ salesDates: state.salesDates }));
 
   const isDataEntered = count !== 0;
+
+  const excludeDate = (date: Date) => {
+    const formattedDate = formatDate(date);
+    return salesDates.includes(formattedDate);
+  };
 
   const icon = <CalendarIcon style={{ width: rem(18), height: rem(18) }}/>;
 
@@ -27,6 +35,7 @@ export default function Datepicker() {
       disabled={isDataEntered}
       valueFormat= "YYYY / MM / DD   ( ddd )"
       maxDate={new Date()}
+      excludeDate={excludeDate}
     />
   );
 }

--- a/app/components/page/DashBoard/Calendar.tsx
+++ b/app/components/page/DashBoard/Calendar.tsx
@@ -1,10 +1,10 @@
 "use client"
 import { useMemo } from 'react';
-import { useDisclosure } from '@mantine/hooks';
-import { DatePicker } from '@mantine/dates';
-import dayjs from 'dayjs';
+import { formatDate } from '@/utils/dateUtils';
 import useCalculationStore from '@/store/calculationStore';
 import useDashboardStore from '@/store/dashboardStore';
+import { useDisclosure } from '@mantine/hooks';
+import { DatePicker } from '@mantine/dates';
 import SalesModal from './SalesModal';
 import SalesIndicator from './SalesIndicator';
 
@@ -25,14 +25,14 @@ export default function Calender() {
   const selectedSalesRecord = useMemo(() => {
     if (selectedDate) {
       // dayjsを使って日付をフォーマット
-      const formattedDate = dayjs(selectedDate).format('YYYY-MM-DD');
+      const formattedDate = formatDate(selectedDate)
       return salesRecords.find((record) => record.date === formattedDate);
     }
     return null;
   }, [selectedDate, salesRecords]);
 
   // 売上記録が存在する日付の配列を作成
-  const salesDates = salesRecords.map(record => dayjs(record.date).format('YYYY-MM-DD'));
+  const salesDates = salesRecords.map(record => formatDate(record.date));
 
   // Calender.js 内での使用
   const renderDay = (date: Date) => {

--- a/app/components/page/DashBoard/Calendar.tsx
+++ b/app/components/page/DashBoard/Calendar.tsx
@@ -12,29 +12,25 @@ export default function Calender() {
   const [opened, { open, close }] = useDisclosure(false);
   const { selectedDate, setSelectedDate } = useCalculationStore();
   const { salesRecords } = useDashboardStore((state) => ({ salesRecords: state.salesRecords }));
+  const { salesDates } = useDashboardStore((state) => ({ salesDates: state.salesDates }));
 
 
   const handleDateChange = (date: Date | null) => {
     if (date !== null) {
       setSelectedDate(date);
     }
-    open(); // モーダルを開く
+    open();
   };
 
   // 選択された日付に対応する売上記録を取得
   const selectedSalesRecord = useMemo(() => {
     if (selectedDate) {
-      // dayjsを使って日付をフォーマット
       const formattedDate = formatDate(selectedDate)
-      return salesRecords.find((record) => record.date === formattedDate);
+      return salesRecords.find((record) => record.date === formattedDate) || null;;
     }
     return null;
   }, [selectedDate, salesRecords]);
 
-  // 売上記録が存在する日付の配列を作成
-  const salesDates = salesRecords.map(record => formatDate(record.date));
-
-  // Calender.js 内での使用
   const renderDay = (date: Date) => {
     return <SalesIndicator date={date} salesDates={salesDates} />;
   };

--- a/app/components/page/DashBoard/Calendar.tsx
+++ b/app/components/page/DashBoard/Calendar.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import { useState,useMemo } from 'react';
+import { useDisclosure } from '@mantine/hooks';
+import { DatePicker, DatePickerProps } from '@mantine/dates';
+import { Modal } from '@mantine/core';
+import { Indicator } from '@mantine/core';
+import dayjs from 'dayjs';
+
+export default function Calender() {
+  const [value, setValue] = useState<Date | null>(null);
+
+  return (
+    <>
+    <DatePicker allowDeselect value={value} onChange={setValue} />
+    </>
+  );
+}

--- a/app/components/page/DashBoard/Calendar.tsx
+++ b/app/components/page/DashBoard/Calendar.tsx
@@ -1,18 +1,57 @@
 "use client"
 
-import { useState,useMemo } from 'react';
+import { useMemo } from 'react';
 import { useDisclosure } from '@mantine/hooks';
 import { DatePicker, DatePickerProps } from '@mantine/dates';
 import { Modal } from '@mantine/core';
 import { Indicator } from '@mantine/core';
 import dayjs from 'dayjs';
+import useCalculationStore from '@/store/calculationStore';
+import useDashboardStore from '@/store/dashboardStore';
+import DayRecord from './DayRecord';
+import NotDayRecord from './NotDayRecord';
 
 export default function Calender() {
-  const [value, setValue] = useState<Date | null>(null);
+  const [opened, { open, close }] = useDisclosure(false);
+  const { selectedDate, setSelectedDate } = useCalculationStore();
+  const { salesRecords } = useDashboardStore((state) => ({ salesRecords: state.salesRecords }));
+
+
+  const handleDateChange = (date: any) => {
+    setSelectedDate(date);
+    open(); // モーダルを開く
+  };
+
+  // 選択された日付に対応する売上記録を取得
+  const selectedSalesRecord = useMemo(() => {
+    if (selectedDate) {
+      // dayjsを使って日付をフォーマット
+      const formattedDate = dayjs(selectedDate).format('YYYY-MM-DD');
+      return salesRecords.find((record) => record.date === formattedDate);
+    }
+    return null;
+  }, [selectedDate, salesRecords]);
+
+  // モーダルの中身を決定する関数
+  const renderModalContent = () => {
+  if (selectedSalesRecord) {
+    return <><DayRecord record={selectedSalesRecord} /></>;
+  } else {
+    return <><NotDayRecord /></>;
+  }
+};
 
   return (
     <>
-    <DatePicker allowDeselect value={value} onChange={setValue} />
+    <DatePicker allowDeselect onChange={handleDateChange} />
+
+    <Modal
+        opened={opened}
+        onClose={close}
+        centered
+      >
+        {renderModalContent()}
+    </Modal>
     </>
   );
 }

--- a/app/components/page/DashBoard/Calendar.tsx
+++ b/app/components/page/DashBoard/Calendar.tsx
@@ -1,15 +1,12 @@
 "use client"
-
 import { useMemo } from 'react';
 import { useDisclosure } from '@mantine/hooks';
-import { DatePicker, DatePickerProps } from '@mantine/dates';
-import { Modal } from '@mantine/core';
-import { Indicator } from '@mantine/core';
+import { DatePicker } from '@mantine/dates';
 import dayjs from 'dayjs';
 import useCalculationStore from '@/store/calculationStore';
 import useDashboardStore from '@/store/dashboardStore';
-import DayRecord from './DayRecord';
-import NotDayRecord from './NotDayRecord';
+import SalesModal from './SalesModal';
+import SalesIndicator from './SalesIndicator';
 
 export default function Calender() {
   const [opened, { open, close }] = useDisclosure(false);
@@ -17,8 +14,10 @@ export default function Calender() {
   const { salesRecords } = useDashboardStore((state) => ({ salesRecords: state.salesRecords }));
 
 
-  const handleDateChange = (date: any) => {
-    setSelectedDate(date);
+  const handleDateChange = (date: Date | null) => {
+    if (date !== null) {
+      setSelectedDate(date);
+    }
     open(); // モーダルを開く
   };
 
@@ -32,26 +31,23 @@ export default function Calender() {
     return null;
   }, [selectedDate, salesRecords]);
 
-  // モーダルの中身を決定する関数
-  const renderModalContent = () => {
-  if (selectedSalesRecord) {
-    return <><DayRecord record={selectedSalesRecord} /></>;
-  } else {
-    return <><NotDayRecord /></>;
-  }
-};
+  // 売上記録が存在する日付の配列を作成
+  const salesDates = salesRecords.map(record => dayjs(record.date).format('YYYY-MM-DD'));
+
+  // Calender.js 内での使用
+  const renderDay = (date: Date) => {
+    return <SalesIndicator date={date} salesDates={salesDates} />;
+  };
 
   return (
     <>
-    <DatePicker allowDeselect onChange={handleDateChange} />
-
-    <Modal
+      <DatePicker allowDeselect onChange={handleDateChange} renderDay={renderDay} maxDate={new Date()}/>
+      <SalesModal 
         opened={opened}
-        onClose={close}
-        centered
-      >
-        {renderModalContent()}
-    </Modal>
+        close={close}
+        selectedSalesRecord={selectedSalesRecord}
+        selectedDate={selectedDate}
+      />
     </>
   );
 }

--- a/app/components/page/DashBoard/DayRecord.tsx
+++ b/app/components/page/DashBoard/DayRecord.tsx
@@ -1,11 +1,6 @@
-type SalesRecord = {
-  average_spend: number
-  count: number
-  date: Date
-  set_rate: number
-  total_amount: number
-  total_number: number
-};
+import { SalesRecord } from "@/types/SalesRecord";
+import {  CurrencyYenIcon } from "@heroicons/react/24/outline";
+import { ShoppingBagIcon,UserIcon } from "@heroicons/react/24/solid";
 
 type DayRecordProps = {
   record: SalesRecord;
@@ -16,13 +11,26 @@ export default function DayRecord({ record }: DayRecordProps) {
   const formatCurrency = (amount :number) => {
     return new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(amount);
   }
-    return (
-      <>
-      <div className="p-4">
-        <div className="mb-2">売上金額：{formatCurrency(record.total_amount)}</div>
-        <div className="mb-2">セット率：{record.set_rate}</div>
-        <div className="mb-2">客単価：{formatCurrency(record.average_spend)}</div>
+
+  return (
+    <>
+      <div className="p-4 border-t">
+        <div className="mb-2 flex items-center text-gray-700">
+          <CurrencyYenIcon className="w-6 h-6 text-gray-500 mr-2" />
+          売上金額：
+          <span>{formatCurrency(record.total_amount)}</span>
+        </div>
+        <div className="mb-2 flex items-center text-gray-700">
+          <UserIcon className="w-6 h-6 text-gray-500 mr-2" />
+          客単価：
+          <span>{formatCurrency(record.average_spend)} （客数: {record.count}）</span>
+        </div>
+        <div className="mb-2 flex items-center text-gray-700">
+          <ShoppingBagIcon className="w-6 h-6 text-gray-500 mr-2" />
+          セット率：
+          <span>{record.set_rate} （点数: {record.total_number}）</span>
+        </div>
       </div>
-      </>
-    )
-  }
+    </>
+  )
+}

--- a/app/components/page/DashBoard/DayRecord.tsx
+++ b/app/components/page/DashBoard/DayRecord.tsx
@@ -1,0 +1,28 @@
+type SalesRecord = {
+  average_spend: number
+  count: number
+  date: Date
+  set_rate: number
+  total_amount: number
+  total_number: number
+};
+
+type DayRecordProps = {
+  record: SalesRecord;
+};
+
+export default function DayRecord({ record }: DayRecordProps) {
+
+  const formatCurrency = (amount :number) => {
+    return new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(amount);
+  }
+    return (
+      <>
+      <div className="p-4">
+        <div className="mb-2">売上金額：{formatCurrency(record.total_amount)}</div>
+        <div className="mb-2">セット率：{record.set_rate}</div>
+        <div className="mb-2">客単価：{formatCurrency(record.average_spend)}</div>
+      </div>
+      </>
+    )
+  }

--- a/app/components/page/DashBoard/NotDayRecord.tsx
+++ b/app/components/page/DashBoard/NotDayRecord.tsx
@@ -7,11 +7,14 @@ export default function NotDayRecord() {
   const router = useRouter()
   return (
     <>
-      <div className="p-4">
-        <div className="mb-2">売上を記録しますか？</div>
-        <Button type="submit" variant="outline" color="gray" size="xs" onClick={() => router.push('/dairyrecord')}>
+      <div className="p-4 border-t">
+        <div className="mb-2">
+          <p>売上データがありません。</p>
+          <p>売上を記録しますか？</p>
+        </div>
+        <Button type="submit" variant="outline" color="gray" size="sm" onClick={() => router.push('/dairyrecord')}>
           記録しにいく
-          <CursorArrowRaysIcon className="w-5 h-5 ml-1 text-blue-400" />
+          <CursorArrowRaysIcon className="w-6 h-6 ml-1 text-blue-400" />
         </Button>
       </div>
     </>

--- a/app/components/page/DashBoard/NotDayRecord.tsx
+++ b/app/components/page/DashBoard/NotDayRecord.tsx
@@ -1,0 +1,19 @@
+"use client"
+import { useRouter } from 'next/navigation'
+import { Button } from '@mantine/core';
+import { CursorArrowRaysIcon } from "@heroicons/react/24/solid";
+
+export default function NotDayRecord() {
+  const router = useRouter()
+  return (
+    <>
+      <div className="p-4">
+        <div className="mb-2">売上を記録しますか？</div>
+        <Button type="submit" variant="outline" color="gray" size="xs" onClick={() => router.push('/dairyrecord')}>
+          記録しにいく
+          <CursorArrowRaysIcon className="w-5 h-5 ml-1 text-blue-400" />
+        </Button>
+      </div>
+    </>
+  )
+}

--- a/app/components/page/DashBoard/SalesIndicator.tsx
+++ b/app/components/page/DashBoard/SalesIndicator.tsx
@@ -1,0 +1,18 @@
+import { Indicator } from '@mantine/core';
+import dayjs from 'dayjs';
+
+type SalesIndicatorProps = {
+    date: Date;
+    salesDates: string[];
+};
+
+export default function SalesIndicator({ date, salesDates }:SalesIndicatorProps ) {
+  const dateString = dayjs(date).format('YYYY-MM-DD');
+  const isSaleDay = salesDates.includes(dateString);
+
+  return (
+    <Indicator size={5} color="rgba(87, 147, 250, 0.38)" offset={-5} disabled={!isSaleDay}>
+      {date.getDate()}
+    </Indicator>
+  )
+}

--- a/app/components/page/DashBoard/SalesIndicator.tsx
+++ b/app/components/page/DashBoard/SalesIndicator.tsx
@@ -1,5 +1,5 @@
+import { formatDate } from '@/utils/dateUtils';
 import { Indicator } from '@mantine/core';
-import dayjs from 'dayjs';
 
 type SalesIndicatorProps = {
     date: Date;
@@ -7,7 +7,7 @@ type SalesIndicatorProps = {
 };
 
 export default function SalesIndicator({ date, salesDates }:SalesIndicatorProps ) {
-  const dateString = dayjs(date).format('YYYY-MM-DD');
+  const dateString = formatDate(date)
   const isSaleDay = salesDates.includes(dateString);
 
   return (

--- a/app/components/page/DashBoard/SalesModal.tsx
+++ b/app/components/page/DashBoard/SalesModal.tsx
@@ -2,7 +2,7 @@ import { SalesRecord } from '@/types/SalesRecord';
 import { Modal } from '@mantine/core';
 import DayRecord from './DayRecord';
 import NotDayRecord from './NotDayRecord';
-import dayjs from 'dayjs';
+import { formatDateLayout } from '@/utils/dateUtils';
 
 type SalesModalProps = {
     opened: boolean;
@@ -18,7 +18,7 @@ export default function SalesModal({ opened, close, selectedSalesRecord, selecte
       return (
         <>
           <div className='flex flex-row items-center w-full px-4 py-1 font-bold text-gray-500'>
-            {dayjs(selectedDate).format('YYYY / MM / DD ( ddd )')}
+            {formatDateLayout(selectedDate)}
           </div>
         </>
       );

--- a/app/components/page/DashBoard/SalesModal.tsx
+++ b/app/components/page/DashBoard/SalesModal.tsx
@@ -1,0 +1,46 @@
+import { SalesRecord } from '@/types/SalesRecord';
+import { Modal } from '@mantine/core';
+import DayRecord from './DayRecord';
+import NotDayRecord from './NotDayRecord';
+import dayjs from 'dayjs';
+
+type SalesModalProps = {
+    opened: boolean;
+    close: () => void;
+    selectedSalesRecord: SalesRecord | null;
+    selectedDate: Date | null;
+};
+
+export default function SalesModal({ opened, close, selectedSalesRecord, selectedDate }: SalesModalProps) {
+
+  const renderModalTitle = () => {
+    if (selectedDate) {
+      return (
+        <>
+          <div className='flex flex-row items-center w-full px-4 py-1 font-bold text-gray-500'>
+            {dayjs(selectedDate).format('YYYY / MM / DD ( ddd )')}
+          </div>
+        </>
+      );
+    }
+  };
+
+  const renderModalContent = () => {
+    if (selectedSalesRecord) {
+      return <DayRecord record={selectedSalesRecord} />;
+    } else {
+      return <NotDayRecord />;
+    }
+  };
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={close}
+      title={renderModalTitle()}
+      centered
+    >
+      {renderModalContent()}
+    </Modal>
+  )
+}

--- a/app/components/page/DashBoard/ThisWeek.tsx
+++ b/app/components/page/DashBoard/ThisWeek.tsx
@@ -1,0 +1,9 @@
+export default function ThisWeek() {
+    return (
+      <>
+        <div className="flex flex-row justify-center items-center w-fll h-20 px-6">
+          <p>ダッシュボードです。アンニョン</p>
+        </div>
+      </>
+    );
+  }

--- a/lib/useFetchData.ts
+++ b/lib/useFetchData.ts
@@ -1,0 +1,16 @@
+"use client"
+import { useSession } from 'next-auth/react';
+import { useEffect } from 'react';
+import useDashboardStore from '@/store/dashboardStore';
+
+export const useFetchData = () => {
+  const { data: session } = useSession();
+  const railsUserId = session?.user?.railsId;
+  const fetchData = useDashboardStore((state) => state.fetchData);
+
+  useEffect(() => {
+    if (railsUserId) {
+      fetchData(railsUserId);
+    }
+  }, [railsUserId, fetchData]);
+}

--- a/store/calculationStore.ts
+++ b/store/calculationStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import dayjs from 'dayjs';
+import { formatDate } from '@/utils/dateUtils';
 
 type Option = {
   value: number;
@@ -88,7 +88,7 @@ const useCalculationStore = create<CalculationState>((set, get) => ({
   // 送信アクション
   submitData: () => {
     const { totalAmount, totalNumber, count, customerTypeCounts, selectedDate } = get();
-    const formattedDate = dayjs(selectedDate).format('YYYY-MM-DD');
+    const formattedDate = formatDate(selectedDate)
     const dairy_record = {
       total_amount: totalAmount,
       total_number: totalNumber,

--- a/store/calculationStore.ts
+++ b/store/calculationStore.ts
@@ -83,7 +83,7 @@ const useCalculationStore = create<CalculationState>((set, get) => ({
   },
 
   // クリアアクション
-  clearData: () => set({ totalAmount: 0, totalNumber: 0, count: 0, customers: [], selectedDate: new Date(), customerLabels: ''}),
+  clearData: () => set({ totalAmount: 0, totalNumber: 0, count: 0, customers: [], customerLabels: ''}),
 
   // 送信アクション
   submitData: () => {

--- a/store/dashboardStore.ts
+++ b/store/dashboardStore.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+
+type DashboardState = {
+  salesRecords: any[]; 
+  fetchData: (userId: number, force?: boolean) => Promise<void>;
+  lastFetchedUserId: number | null;
+};
+
+const useDashboardStore = create<DashboardState>((set, get) => ({
+  salesRecords: [],
+  lastFetchedUserId: null,
+
+  fetchData: async (userId, force = false) => {
+    if (force || get().lastFetchedUserId !== userId || get().salesRecords.length === 0) {
+      try {
+        const response = await fetch(`/api/salesrecord`);
+
+        if (!response.ok) { throw new Error('サーバーエラー')}
+
+        const data = await response.json();
+        set({ salesRecords: data, lastFetchedUserId: userId });
+
+      } catch (error) {
+        console.error("Failed to fetch", error);
+      }
+    }
+  },
+}))
+
+export default useDashboardStore ;

--- a/store/dashboardStore.ts
+++ b/store/dashboardStore.ts
@@ -1,13 +1,16 @@
 import { create } from 'zustand';
+import { SalesRecord } from '@/types/SalesRecord';
 
 type DashboardState = {
-  salesRecords: any[]; 
+  salesRecords: SalesRecord[];
+  salesDates: string[];
   fetchData: (userId: number, force?: boolean) => Promise<void>;
   lastFetchedUserId: number | null;
 };
 
 const useDashboardStore = create<DashboardState>((set, get) => ({
   salesRecords: [],
+  salesDates: [], // 売上記録の日付データ
   lastFetchedUserId: null,
 
   fetchData: async (userId, force = false) => {
@@ -17,8 +20,9 @@ const useDashboardStore = create<DashboardState>((set, get) => ({
 
         if (!response.ok) { throw new Error('サーバーエラー')}
 
-        const data = await response.json();
-        set({ salesRecords: data, lastFetchedUserId: userId });
+        const data: SalesRecord[] = await response.json();
+        const dates = data.map(record => record.date);
+        set({ salesRecords: data, salesDates: dates, lastFetchedUserId: userId });
 
       } catch (error) {
         console.error("Failed to fetch", error);

--- a/types/SalesRecord.ts
+++ b/types/SalesRecord.ts
@@ -1,7 +1,7 @@
 export type SalesRecord = {
     average_spend: number;
     count: number;
-    date: Date;
+    date: string;
     set_rate: number;
     total_amount: number;
     total_number: number;

--- a/types/SalesRecord.ts
+++ b/types/SalesRecord.ts
@@ -1,0 +1,8 @@
+export type SalesRecord = {
+    average_spend: number;
+    count: number;
+    date: Date;
+    set_rate: number;
+    total_amount: number;
+    total_number: number;
+};

--- a/utils/dateUtils.ts
+++ b/utils/dateUtils.ts
@@ -1,0 +1,9 @@
+import dayjs from 'dayjs';
+
+export const formatDate = (date :Date) => {
+  return dayjs(date).format('YYYY-MM-DD');
+};
+
+export const formatDateLayout = (date :Date) => {
+  return dayjs(date).format("YYYY / MM / DD   ( ddd )");
+};


### PR DESCRIPTION
## 概要

ダッシュボードページ(仮)の作成
issue: #5 

## 変更点

【カレンダーコンポーネントを作成】
- 日付をクリックでモーダルを表示
  - 売上登録あり...その日の実績を表示
  - 売上登録なし...売上登録ページへのリンクボタンを表示。遷移して売上の登録に進める。
 売上登録ページのDatepickerコンポーネントと選択日を共有し、ページ遷移後はその日がセットされている状態。
- 売上登録のある日にはインジケータを表示

【売上一覧の取得】
- APIルートを介してRailsバックエンドから取得
- 取得した一覧をストアで管理し、Datepicker等のコンポーネントに使用する


## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0
- バックエンドから期待される一覧データの取得を確認
- カレンダーコンポーネント, Datepicker各機能の動作を確認

## 影響範囲
- /dashboard
- /dairyrecord

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応