### PR TITLE
🐛 Fix: fetchDate

### DIFF
--- a/app/(authenticated)/dashboard/page.tsx
+++ b/app/(authenticated)/dashboard/page.tsx
@@ -1,5 +1,5 @@
 "use client"
-import Calender from "@/app/components/page/DashBoard/Calendar";
+import CalenderArea from "@/app/components/page/DashBoard/CalenderArea";
 import ThisWeek from "@/app/components/page/DashBoard/ThisWeek";
 import { useFetchData } from "@/lib/useFetchData";
 
@@ -12,9 +12,7 @@ export default function Dashboard() {
       <div className="p-7 shadow-md">
         <ThisWeek/>
       </div>
-      <div className="bg-white p-7 shadow-md">
-        <Calender/>
-      </div>
+      <CalenderArea/>
     </div>
     </>
   )

--- a/app/components/page/DairyRecord/Submit.tsx
+++ b/app/components/page/DairyRecord/Submit.tsx
@@ -1,7 +1,9 @@
 "use client"
 import { useRouter } from 'next/navigation'
+import { useSession } from 'next-auth/react';
 import axios from 'axios'
 import useCalculationStore from '@/store/calculationStore';
+import useDashboardStore from '@/store/dashboardStore';
 import CurrentData from './CurrentData';
 import ClearButton from '../../ui/ClearButton';
 import SubmitButton from '../../ui/SubmitButton';
@@ -12,8 +14,11 @@ import { showErrorNotification } from '@/utils/notifications';
 import { showSuccessNotification } from '@/utils/notifications';
 
 export default function Submit() {
-  const { clearData, submitData } = useCalculationStore();
   const router = useRouter()
+  const { data: session } = useSession();
+  const railsUserId = session?.user?.railsId;
+  const { clearData, submitData } = useCalculationStore();
+  const { fetchData } = useDashboardStore((state) => ({fetchData: state.fetchData,}));
 
   const handleSubmit = async () => {
     const { dairy_record, customer_counts } = submitData();
@@ -35,7 +40,10 @@ export default function Submit() {
       const date = response.data.dairy_record.date;
       showSuccessNotification(`${date}の売上を登録しました`);
       clearData();
-      router.push('/dashboard'); 
+      if (railsUserId !== undefined) {
+        fetchData(railsUserId, true);
+      }
+      router.push('/dashboard');
     } catch (error) {
       showErrorNotification('送信に失敗しました。もう一度お試しください。');
       console.error("Failed to fetch", error);

--- a/app/components/page/DashBoard/CalenderArea.tsx
+++ b/app/components/page/DashBoard/CalenderArea.tsx
@@ -1,0 +1,13 @@
+import Calender from "./Calendar"
+
+export default function CalenderArea() {
+  return (
+    <div className="bg-white p-7 shadow-md flex flex-col">
+      <div className="flex flex-row justify-end items-center w-full text-gray-400 px-2 mb-2">
+        <span className="text-xs text-blue-300 mr-1">⚫︎</span>
+        <span className="text-xs">売上記録した日</span>
+      </div>
+      <Calender/>
+    </div>
+  )
+}

--- a/app/components/page/DashBoard/SalesIndicator.tsx
+++ b/app/components/page/DashBoard/SalesIndicator.tsx
@@ -11,7 +11,7 @@ export default function SalesIndicator({ date, salesDates }:SalesIndicatorProps 
   const isSaleDay = salesDates.includes(dateString);
 
   return (
-    <Indicator size={5} color="rgba(87, 147, 250, 0.38)" offset={-5} disabled={!isSaleDay}>
+    <Indicator size={6} color="#93c5fd" offset={-5} disabled={!isSaleDay}>
       {date.getDate()}
     </Indicator>
   )


### PR DESCRIPTION
## 概要

売上登録成功後のリダイレクト時に強制的にfetchDataを行う。

issue: #17 

## 変更点
- 変更前
fetchDateが走るのは/dashboardに訪れた初回、またUserが変更された時のみ（サーバーへのリクエストを最小限にしたい）。
このため、リダイレクトで/dashboardに遷移した際にデータが更新されない為、直前に登録した内容が反映されない。

- 変更後
売上登録ボタン（hundleSubmit）で router.push前にfetchDateを呼び、/dashboardに遷移後に最新のデータを反映させる
インジケータやモーダルで直前の登録内容が確認可能。

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0

- 画面遷移後、最新のデータがカレンダーに反映されていることを確認

## 影響範囲
- /dashboard
- /dairyrecord

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応