### PR TITLE
🐛  Fix: clearData処理を修正

### DIFF
--- a/store/calculationStore.ts
+++ b/store/calculationStore.ts
@@ -83,7 +83,7 @@ const useCalculationStore = create<CalculationState>((set, get) => ({
   },
 
   // クリアアクション
-  clearData: () => set({ totalAmount: 0, totalNumber: 0, count: 0, customers: [], customerLabels: ''}),
+  clearData: () => set({ totalAmount: 0, totalNumber: 0, count: 0, customers: [], customerLabels: '', customerTypeCounts: {} }),
 
   // 送信アクション
   submitData: () => {


### PR DESCRIPTION
## 概要

売上送信後、{ 客層タイプ：カウント }のcustomerTypeCountsがリセットされず、繰り返し登録する際に前のデータを引き継いでしまう問題を修正。

issue: #19 

## 変更点

- clearData関数を修正

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0


## 影響範囲
- /dairyrecord

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応