### PR TITLE
get customer_option #15

### DIFF
--- a/app/api/customer_types/route.ts
+++ b/app/api/customer_types/route.ts
@@ -1,0 +1,28 @@
+import axios from 'axios';
+
+export async function GET()  {
+
+  const apiUrl = process.env.RAILS_API_URL
+
+  try {
+    const response = await axios.get(`${apiUrl}/customer_types`, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+    return new Response(JSON.stringify(response.data), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    return new Response(JSON.stringify({ error:'予期せぬエラーが発生しました' }), {
+      status: 500,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+}

--- a/app/components/page/DairyRecord/RecordInputForm.tsx
+++ b/app/components/page/DairyRecord/RecordInputForm.tsx
@@ -1,3 +1,5 @@
+"use client"
+import { useEffect } from 'react';
 import { z } from 'zod';
 import { useForm } from '@mantine/form';
 import { zodResolver } from 'mantine-form-zod-resolver';
@@ -18,7 +20,7 @@ const schema  = z.object({
 });
 
 export default function RecordInputForm () {
-  const { addToTotal, options } = useCalculationStore();
+  const { addToTotal, options, fetchOptions } = useCalculationStore();
 
   const form = useForm({
     initialValues: {
@@ -33,6 +35,10 @@ export default function RecordInputForm () {
     addToTotal(values);
     form.reset();
   };
+
+  useEffect(() => {
+    fetchOptions();
+  }, [fetchOptions]);
 
   return (
     <>

--- a/store/calculationStore.ts
+++ b/store/calculationStore.ts
@@ -36,6 +36,7 @@ type CalculationState = {
   setSelectedDate: (date: Date) => void;
   addToTotal: (params: AddToTotalParams) => void;
   submitData: () => SubmitDataType;
+  fetchOptions: () => Promise<void>;
   clearData: () => void;
   calculateCustomerCounts: (customers: string[]) => Record<string, number>;
   generateCustomerLabels: (customerTypeCounts: Record<string, number>) => string;
@@ -49,17 +50,7 @@ const useCalculationStore = create<CalculationState>((set, get) => ({
   customers: [], // 選択された客層 ['1', '2', '1'] 
   customerLabels: '', // 表示用に変換 "主婦: 2、 OL: 1"
   selectedDate: new Date(),
-  options: [
-    { value: 1, label: "主婦" },
-    { value: 2, label: "OL" },
-    { value: 3, label: "~30代" },
-    { value: 4, label: "~40代" },
-    { value: 5, label: "アッパー" },
-    { value: 6, label: "学生" },
-    { value: 7, label: "ギフト" },
-    { value: 8, label: "顧客" },
-    { value: 9, label: "その他" },
-  ],
+  options: [],
 
   // 日付の更新
   setSelectedDate: (date: Date) => {
@@ -98,6 +89,20 @@ const useCalculationStore = create<CalculationState>((set, get) => ({
     const customer_counts = customerTypeCounts;
 
     return { dairy_record, customer_counts };
+  },
+
+  fetchOptions: async () => {
+    try {
+      const response = await fetch(`/api/customer_types`);
+
+      if (!response.ok) { throw new Error('サーバーエラー'); }
+
+      const optionsData = await response.json();
+      set({ options: optionsData });
+      
+    } catch (error) {
+      console.error("Failed to fetch options", error);
+    }
   },
 
   // customers配列を集計


### PR DESCRIPTION
## 概要

客層の選択肢をバックエンドから取得

issue: #15 

## 変更点

【変更前】
- 客層options配列をストア内に直接記述

【変更後】
- fetchOptions関数,APIルートを作成
客層options配列をバックエンドから取得、ストアで管理

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0
- 期待するデータの取得を確認
- フォームでの表示、登録できることを確認

## 影響範囲
- /dairyrecord

## チェックリスト

- [x] Lintチェックをパスした