### PR TITLE
StepForm_4 #28

### DIFF
--- a/app/(authenticated)/dashboard/page.tsx
+++ b/app/(authenticated)/dashboard/page.tsx
@@ -1,11 +1,7 @@
-"use client"
 import CalenderArea from "@/app/components/page/DashBoard/CalenderArea";
 import ThisWeek from "@/app/components/page/DashBoard/ThisWeek";
-import { useFetchData } from "@/lib/useFetchData";
 
-export default function Dashboard() {
-  useFetchData();
-  
+export default function Dashboard() {  
   return (
     <>
     <div className="flex flex-col md:flex-row justify-center items-center mx-auto p-6 z-0 md:gap-x-6 max-w-5xl my-10">

--- a/app/api/weeklyreport/route.ts
+++ b/app/api/weeklyreport/route.ts
@@ -2,6 +2,46 @@ import axios from 'axios';
 import { getServerSession } from "next-auth/next"
 import { options } from '@/lib/options';
 
+export async function GET() {
+
+  const session = await getServerSession(options);
+    
+  if (!session) {
+    return new Response(JSON.stringify({ error: '認証が必要です' }), {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  const railsUserId = session.user.railsId;
+  const apiUrl = process.env.RAILS_API_URL
+
+  try {
+    const response = await axios.get(`${apiUrl}/weekly_reports`, {
+      headers: {
+        'user': `${railsUserId}`,
+        'Content-Type': 'application/json',
+      },
+    });
+    return new Response(JSON.stringify(response.data), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    return new Response(JSON.stringify({ error:'予期せぬエラーが発生しました' }), {
+      status: 500,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+}
+
 export async function POST(request: Request) {
 
   const session = await getServerSession(options);

--- a/app/api/weeklytarget/route.ts
+++ b/app/api/weeklytarget/route.ts
@@ -2,6 +2,46 @@ import axios from 'axios';
 import { getServerSession } from "next-auth/next"
 import { options } from '@/lib/options';
 
+export async function GET() {
+
+  const session = await getServerSession(options);
+    
+  if (!session) {
+    return new Response(JSON.stringify({ error: '認証が必要です' }), {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  const railsUserId = session.user.railsId;
+  const apiUrl = process.env.RAILS_API_URL
+
+  try {
+    const response = await axios.get(`${apiUrl}/weekly_targets`, {
+      headers: {
+        'user': `${railsUserId}`,
+        'Content-Type': 'application/json',
+      },
+    });
+    return new Response(JSON.stringify(response.data), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    return new Response(JSON.stringify({ error:'予期せぬエラーが発生しました' }), {
+      status: 500,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+}
+
 export async function POST(request: Request) {
 
   const session = await getServerSession(options);

--- a/app/components/page/DairyRecord/Caluculator.tsx
+++ b/app/components/page/DairyRecord/Caluculator.tsx
@@ -1,9 +1,13 @@
 "use client"
+import { useFetchResisterdDay } from '@/lib/useFetchData';
 import { Fieldset } from '@mantine/core';
 import RecordInputForm from './RecordInputForm';
 import Datepicker from './DatePicker';
 
 export default function Caluculator() {
+
+  useFetchResisterdDay();
+
   return (
     <>
     <div className="flex flex-col w-full max-w-lg">

--- a/app/components/page/DairyRecord/Submit.tsx
+++ b/app/components/page/DairyRecord/Submit.tsx
@@ -17,7 +17,7 @@ export default function Submit() {
   const { data: session } = useSession();
   const railsUserId = session?.user?.railsId;
   const { clearData, submitData } = useCalculationStore();
-  const { fetchData } = useDashboardStore((state) => ({fetchData: state.fetchData,}));
+  const { fetchSalesRecord } = useDashboardStore((state) => ({fetchSalesRecord: state.fetchSalesRecord,}));
 
   const handleSubmit = async () => {
     const { dairy_record, customer_counts } = submitData();
@@ -40,7 +40,7 @@ export default function Submit() {
       showSuccessNotification(`${date}の売上を登録しました`);
       clearData();
       if (railsUserId !== undefined) {
-        fetchData(railsUserId, true);
+        fetchSalesRecord(railsUserId, true);
       }
       router.push('/dashboard');
     } catch (error) {

--- a/app/components/page/DashBoard/Calendar.tsx
+++ b/app/components/page/DashBoard/Calendar.tsx
@@ -1,4 +1,5 @@
 "use client"
+import { useFetchData } from '@/lib/useFetchData';
 import { useMemo } from 'react';
 import { formatDate } from '@/utils/dateUtils';
 import useCalculationStore from '@/store/calculationStore';
@@ -9,6 +10,8 @@ import SalesModal from './SalesModal';
 import SalesIndicator from './SalesIndicator';
 
 export default function Calender() {
+  useFetchData();
+  
   const [opened, { open, close }] = useDisclosure(false);
   const { selectedDate, setSelectedDate } = useCalculationStore();
   const { salesRecords } = useDashboardStore((state) => ({ salesRecords: state.salesRecords }));

--- a/app/components/page/DashBoard/DayRecord.tsx
+++ b/app/components/page/DashBoard/DayRecord.tsx
@@ -1,4 +1,4 @@
-import { SalesRecord } from "@/types/SalesRecord";
+import { SalesRecord } from "@/types";
 import {  CurrencyYenIcon } from "@heroicons/react/24/outline";
 import { ShoppingBagIcon,UserIcon } from "@heroicons/react/24/solid";
 

--- a/app/components/page/DashBoard/SalesModal.tsx
+++ b/app/components/page/DashBoard/SalesModal.tsx
@@ -1,4 +1,4 @@
-import { SalesRecord } from '@/types/SalesRecord';
+import { SalesRecord } from '@/types';
 import { Modal } from '@mantine/core';
 import DayRecord from './DayRecord';
 import NotDayRecord from './NotDayRecord';

--- a/app/components/page/StepForm/StepForm.tsx
+++ b/app/components/page/StepForm/StepForm.tsx
@@ -1,6 +1,7 @@
 "use client"
 import { useState } from 'react';
 import { useRouter } from 'next/navigation'
+import { useFetchData } from '@/lib/useFetchData';
 import axios from 'axios'
 import useWeeklyStore from '@/store/weeklyStore';
 import { showErrorNotification, showSuccessNotification, showCautionNotification } from '@/utils/notifications';
@@ -14,6 +15,7 @@ import SkipButton from '../../ui/button/SkipButton';
 import SubmitButton from '../../ui/button/SubmitButton';
 
 export default function StepForm() {
+  useFetchData();
   const router = useRouter()
   const { target, setTarget, clearData, validateTarget, validateContent, getWeeklyReportData, getWeeklyTargetData } = useWeeklyStore();
 

--- a/app/components/page/WeeklyReport.tsx/RepotRangeInput.tsx
+++ b/app/components/page/WeeklyReport.tsx/RepotRangeInput.tsx
@@ -20,9 +20,11 @@ export default function ReportRangeInput() {
     }
   };
 
+  const maxDate = getEndOfWeek(new Date());
+
   const excludeDate = (date: Date) => {
     return isDateInRanges(date, registeredReportRanges);
   };
 
-  return <WeekPicker value={contentDateRange} handleChange={handleChange} excludeDate={excludeDate}/>
+  return <WeekPicker value={contentDateRange} handleChange={handleChange} excludeDate={excludeDate} maxDate={maxDate}/>
 }

--- a/app/components/page/WeeklyReport.tsx/RepotRangeInput.tsx
+++ b/app/components/page/WeeklyReport.tsx/RepotRangeInput.tsx
@@ -1,12 +1,15 @@
 import dayjs from 'dayjs';
 import { getStartOfWeek } from '@/utils/dateUtils';
 import { getEndOfWeek } from '@/utils/dateUtils';
+import { isDateInRanges } from '@/utils/dateUtils';
+import useDashboardStore from '@/store/dashboardStore';
 import useWeeklyStore from '@/store/weeklyStore';
 import WeekPicker from '../../ui/WeekPicker';
 
 export default function ReportRangeInput() {
 
   const { contentDateRange, setContentDateRange } = useWeeklyStore();
+  const { registeredReportRanges } = useDashboardStore((state) => ({ registeredReportRanges: state.registeredReportRanges }));
 
   const handleChange = (newValue: [Date | null, Date | null]) => {
     // 新しい週の範囲を計算してセットする
@@ -17,5 +20,9 @@ export default function ReportRangeInput() {
     }
   };
 
-  return <WeekPicker value={contentDateRange} handleChange={handleChange} />
+  const excludeDate = (date: Date) => {
+    return isDateInRanges(date, registeredReportRanges);
+  };
+
+  return <WeekPicker value={contentDateRange} handleChange={handleChange} excludeDate={excludeDate}/>
 }

--- a/app/components/page/WeeklyTarget/TargetRangeInput.tsx
+++ b/app/components/page/WeeklyTarget/TargetRangeInput.tsx
@@ -1,12 +1,15 @@
 import dayjs from 'dayjs';
 import { getStartOfWeek } from '@/utils/dateUtils';
 import { getEndOfWeek } from '@/utils/dateUtils';
+import { isDateInRanges } from '@/utils/dateUtils';
+import useDashboardStore from '@/store/dashboardStore';
 import useWeeklyStore from '@/store/weeklyStore';
 import WeekPicker from '../../ui/WeekPicker';
 
 export default function TargetRangeInput() {
 
   const { targetDateRange, setTargetDateRange } = useWeeklyStore();
+  const { registeredTargetRanges } = useDashboardStore((state) => ({ registeredTargetRanges: state.registeredTargetRanges }));
 
   const handleChange = (newValue: [Date | null, Date | null]) => {
     // 新しい週の範囲を計算してセットする
@@ -17,5 +20,9 @@ export default function TargetRangeInput() {
     }
   };
 
-  return <WeekPicker value={targetDateRange} handleChange={handleChange}/>
+  const excludeDate = (date: Date) => {
+    return isDateInRanges(date, registeredTargetRanges);
+  };
+
+  return <WeekPicker value={targetDateRange} handleChange={handleChange} excludeDate={excludeDate}/>
 }

--- a/app/components/ui/WeekPicker.tsx
+++ b/app/components/ui/WeekPicker.tsx
@@ -6,9 +6,10 @@ import { rem } from '@mantine/core';
 type WeekPickerProps = {
   value: [Date, Date];
   handleChange: (newValue: [Date | null, Date | null]) => void;
+  excludeDate: (date: Date) => boolean
 }
 
-export default function WeekPicker({ value, handleChange}:WeekPickerProps) {
+export default function WeekPicker({ value, excludeDate, handleChange}:WeekPickerProps) {
 
   const icon = <CalendarIcon style={{ width: rem(18), height: rem(18) }}/>;
 
@@ -25,6 +26,7 @@ export default function WeekPicker({ value, handleChange}:WeekPickerProps) {
         onChange={handleChange}
         withAsterisk
         className='w-full'
+        excludeDate={excludeDate}
       />
   </>
   );

--- a/app/components/ui/WeekPicker.tsx
+++ b/app/components/ui/WeekPicker.tsx
@@ -6,10 +6,11 @@ import { rem } from '@mantine/core';
 type WeekPickerProps = {
   value: [Date, Date];
   handleChange: (newValue: [Date | null, Date | null]) => void;
-  excludeDate: (date: Date) => boolean
+  excludeDate: (date: Date) => boolean;
+  maxDate?: Date;
 }
 
-export default function WeekPicker({ value, excludeDate, handleChange}:WeekPickerProps) {
+export default function WeekPicker({ value, excludeDate, handleChange, maxDate }:WeekPickerProps) {
 
   const icon = <CalendarIcon style={{ width: rem(18), height: rem(18) }}/>;
 
@@ -27,6 +28,7 @@ export default function WeekPicker({ value, excludeDate, handleChange}:WeekPicke
         withAsterisk
         className='w-full'
         excludeDate={excludeDate}
+        maxDate={maxDate}
       />
   </>
   );

--- a/lib/useFetchData.ts
+++ b/lib/useFetchData.ts
@@ -6,11 +6,27 @@ import useDashboardStore from '@/store/dashboardStore';
 export const useFetchData = () => {
   const { data: session } = useSession();
   const railsUserId = session?.user?.railsId;
-  const fetchData = useDashboardStore((state) => state.fetchData);
+  const fetchSalesRecord = useDashboardStore((state) => state.fetchSalesRecord);
+  const fetchWeeklyReport = useDashboardStore((state) => state.fetchWeeklyReport);
+  const fetchWeeklyTarget = useDashboardStore((state) => state.fetchWeeklyTarget);
 
   useEffect(() => {
     if (railsUserId) {
-      fetchData(railsUserId);
+      fetchSalesRecord(railsUserId);
+      fetchWeeklyReport(railsUserId);
+      fetchWeeklyTarget(railsUserId);
     }
-  }, [railsUserId, fetchData]);
+  }, [railsUserId, fetchSalesRecord, fetchWeeklyTarget, fetchWeeklyReport]);
+}
+
+export const useFetchResisterdDay = () => {
+  const { data: session } = useSession();
+  const railsUserId = session?.user?.railsId;
+  const fetchSalesRecord = useDashboardStore((state) => state.fetchSalesRecord);
+
+  useEffect(() => {
+    if (railsUserId) {
+      fetchSalesRecord(railsUserId);
+    }
+  }, [railsUserId, fetchSalesRecord]);
 }

--- a/store/dashboardStore.ts
+++ b/store/dashboardStore.ts
@@ -1,29 +1,68 @@
 import { create } from 'zustand';
-import { SalesRecord } from '@/types/SalesRecord';
+import { SalesRecord, WeeklyTarget, WeeklyReport } from '@/types';
+import { ResisteredDateRange } from '@/types';
 
 type DashboardState = {
   salesRecords: SalesRecord[];
   salesDates: string[];
-  fetchData: (userId: number, force?: boolean) => Promise<void>;
   lastFetchedUserId: number | null;
+  weeklyReports: WeeklyReport[];
+  weeklyTargets: WeeklyTarget[];
+  registeredReportRanges: ResisteredDateRange[];
+  registeredTargetRanges: ResisteredDateRange[];
+  fetchSalesRecord: (userId: number, force?: boolean) => Promise<void>;
+  fetchWeeklyReport: (userId: number, force?: boolean) => Promise<void>;
+  fetchWeeklyTarget: (userId: number, force?: boolean) => Promise<void>;
 };
 
 const useDashboardStore = create<DashboardState>((set, get) => ({
   salesRecords: [],
   salesDates: [], // 売上記録の日付データ
   lastFetchedUserId: null,
+  weeklyReports: [],
+  weeklyTargets: [],
+  registeredReportRanges: [], // 登録したレポートの日付データ
+  registeredTargetRanges: [], // 登録した目標の日付データ
 
-  fetchData: async (userId, force = false) => {
+
+  fetchSalesRecord: async (userId, force = false) => {
     if (force || get().lastFetchedUserId !== userId || get().salesRecords.length === 0) {
       try {
         const response = await fetch(`/api/salesrecord`);
-
-        if (!response.ok) { throw new Error('サーバーエラー')}
-
         const data: SalesRecord[] = await response.json();
         const dates = data.map(record => record.date);
         set({ salesRecords: data, salesDates: dates, lastFetchedUserId: userId });
 
+      } catch (error) {
+        console.error("Failed to fetch", error);
+      }
+    }
+  },
+  fetchWeeklyTarget: async (userId, force = false) => {
+    if (force || get().lastFetchedUserId !== userId || get().weeklyTargets.length === 0) {
+      try {
+        const response = await fetch(`/api/weeklytarget`);
+        const data: WeeklyTarget[] = await response.json();
+        const registeredTargetRanges = data.map(target => ({
+          startDate: target.start_date,
+          endDate: target.end_date
+        }));
+        set({ weeklyTargets: data, registeredTargetRanges, lastFetchedUserId: userId });
+      } catch (error) {
+        console.error("Failed to fetch", error);
+      }
+    }
+  },
+  fetchWeeklyReport: async (userId, force = false) => {
+    if (force || get().lastFetchedUserId !== userId || get().weeklyReports.length === 0) {
+      try {
+        const response = await fetch(`/api/weeklyreport`);
+        const data: WeeklyReport[] = await response.json();
+        const registeredReportRanges = data.map(report => ({
+          startDate: report.start_date,
+          endDate: report.end_date
+        }));
+        set({ weeklyReports: data, registeredReportRanges, lastFetchedUserId: userId });
       } catch (error) {
         console.error("Failed to fetch", error);
       }

--- a/types/SalesRecord.ts
+++ b/types/SalesRecord.ts
@@ -1,8 +1,0 @@
-export type SalesRecord = {
-    average_spend: number;
-    count: number;
-    date: string;
-    set_rate: number;
-    total_amount: number;
-    total_number: number;
-};

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,25 @@
+export type SalesRecord = {
+    average_spend: number;
+    count: number;
+    date: string;
+    set_rate: number;
+    total_amount: number;
+    total_number: number;
+};
+
+export type WeeklyTarget = {
+    target: number;
+    start_date: string;
+    end_date: string;
+};
+
+export type WeeklyReport = {
+    content: string;
+    start_date: string;
+    end_date: string;
+};
+
+export type ResisteredDateRange = {
+    startDate: string;
+    endDate: string;
+};

--- a/utils/dateUtils.ts
+++ b/utils/dateUtils.ts
@@ -1,7 +1,7 @@
+import { ResisteredDateRange } from '@/types';
 import dayjs from 'dayjs';
 import isoWeek from 'dayjs/plugin/isoWeek';
 dayjs.extend(isoWeek);
-
 
 export const formatDate = (date :Date) => {
   return dayjs(date).format('YYYY-MM-DD');
@@ -37,4 +37,16 @@ export const getReportDateRange = (): [Date, Date] => {
   const endOfWeek = getEndOfWeek(todayMinusFourDays)
 
   return [startOfWeek, endOfWeek];
+};
+
+export const isDateInRanges = (date: Date, ranges: ResisteredDateRange[]): boolean => {
+  const checkDate = dayjs(date);
+
+  return ranges.some(range => {
+    const startDate = dayjs(range.startDate);
+    const endDate = dayjs(range.endDate);
+
+    // checkDate が startDate と endDate の間にあるかチェック
+    return checkDate.isAfter(startDate.subtract(1, 'day')) && checkDate.isBefore(endDate.add(1, 'day'));
+  });
 };


### PR DESCRIPTION
## 概要

ステップフォーム内の週選択の制御を追加
issue: #28 

その他：
dashboard外のページでリロードされた際、Datepickerで選択不可にしたい日が反映されない問題を修正

## 変更点

- 登録済みの週間レポート、週間目標をバックエンドから取得しストアで管理する（→このデータは再利用する）
- 取得したデータから登録済みの週をWeekPicker上で選択不可になるようアップデート
上記に加え、レポートのみ来週以降は選択できないよう制限を追加している。
初期値は変更なし。

- 各コンテンツページでリロードされた際にもDatePickerなどの制御ができるようカスタムフックを追加

## 動作確認
macOS, Chromeブラウザ, Node -v18.17.0

- バックエンドから期待するデータを取得できることを確認
- 日付選択が制御できることを確認
- リロード時にも選択不可日が各ページ反映されていることを確認

## 影響範囲
- /dashboard
- /dairyrecord
- /weekly

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応