### PR TITLE
Progress_1 #31

### DIFF
--- a/app/components/page/DashBoard/ThisWeek.tsx
+++ b/app/components/page/DashBoard/ThisWeek.tsx
@@ -1,8 +1,19 @@
+'use client'
+import useDashboardStore from "@/store/dashboardStore";
+
 export default function ThisWeek() {
+
+  const { thisWeekTarget, thisWeekAmount } = useDashboardStore();
+  const thisWeekProgress = useDashboardStore((state) => state.getThisWeekProgress());
     return (
       <>
-        <div className="flex flex-row justify-center items-center w-fll h-20 px-6">
+        <div className="flex flex-col justify-center items-center w-fll h-20 px-6">
           <p>ダッシュボードです。アンニョン</p>
+          <h2>
+            今週の目標: {thisWeekTarget !== null ? thisWeekTarget : "まだ登録されていません"}
+          </h2>
+          <h2>現在の売上: {thisWeekAmount}</h2>
+          <h2>目標まであと: {thisWeekProgress}</h2>
         </div>
       </>
     );

--- a/app/components/page/StepForm/StepForm.tsx
+++ b/app/components/page/StepForm/StepForm.tsx
@@ -1,9 +1,11 @@
 "use client"
 import { useState } from 'react';
 import { useRouter } from 'next/navigation'
+import { useSession } from 'next-auth/react';
 import { useFetchData } from '@/lib/useFetchData';
 import axios from 'axios'
 import useWeeklyStore from '@/store/weeklyStore';
+import useDashboardStore from '@/store/dashboardStore';
 import { showErrorNotification, showSuccessNotification, showCautionNotification } from '@/utils/notifications';
 import Target from './Target';
 import Report from './Report';
@@ -17,7 +19,10 @@ import SubmitButton from '../../ui/button/SubmitButton';
 export default function StepForm() {
   useFetchData();
   const router = useRouter()
+  const { data: session } = useSession();
+  const railsUserId = session?.user?.railsId;
   const { target, setTarget, clearData, validateTarget, validateContent, getWeeklyReportData, getWeeklyTargetData } = useWeeklyStore();
+  const { fetchWeeklyTarget } = useDashboardStore((state) => ({fetchWeeklyTarget: state.fetchWeeklyTarget}));
 
   const [active, setActive] = useState(0);
 
@@ -78,6 +83,9 @@ export default function StepForm() {
       }
     } else {
       showSuccessNotification(`登録しました`);
+    }
+    if (railsUserId !== undefined) {
+      fetchWeeklyTarget(railsUserId, true);
     }
     router.push('/dashboard');
     clearData();


### PR DESCRIPTION
## 概要

今週のデータ（売上金額、目標、目標との差分）を取得しダッシュボードで表示する
issue: #31 

## 変更点

【 fetchSalesRecord関数をアップデート】
- ログイン中ユーザーの売上レコードの一覧取得
- 今週に該当する売上レコード配列を取得　←追加
- 今週の売上金額を算出　←追加

【 fetchWeeklyTarget関数をアップデート】
- ログイン中ユーザーの登録済の週間目標一覧取得
- 今週に該当する目標を取得　←追加

【 getThisWeekProgress関数を追加 】
- 今週の目標と売上金額との差分を算出

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0

- 上記で算出した値をコンポーネントで表示できることを確認

## 影響範囲
- /dashboard

## コメント
値取得の確認のみ。UIは未実装。