### PR TITLE
Progress_2 #36

### DIFF
--- a/app/(authenticated)/dashboard/page.tsx
+++ b/app/(authenticated)/dashboard/page.tsx
@@ -1,11 +1,11 @@
 import CalenderArea from "@/app/components/page/DashBoard/CalenderArea";
-import ThisWeek from "@/app/components/page/DashBoard/ThisWeek";
+import ProgressArea from "@/app/components/page/DashBoard/ProgressArea";
 
 export default function Dashboard() {  
   return (
     <>
     <div className="flex flex-col md:flex-row justify-center items-center mx-auto p-6 z-0 md:gap-x-6 max-w-5xl my-10">
-      <ThisWeek/>
+      <ProgressArea/>
       <CalenderArea/>
     </div>
     </>

--- a/app/(authenticated)/dashboard/page.tsx
+++ b/app/(authenticated)/dashboard/page.tsx
@@ -5,9 +5,7 @@ export default function Dashboard() {
   return (
     <>
     <div className="flex flex-col md:flex-row justify-center items-center mx-auto p-6 z-0 md:gap-x-6 max-w-5xl my-10">
-      <div className="p-7 shadow-md">
-        <ThisWeek/>
-      </div>
+      <ThisWeek/>
       <CalenderArea/>
     </div>
     </>

--- a/app/components/page/DairyRecord/CurrentData.tsx
+++ b/app/components/page/DairyRecord/CurrentData.tsx
@@ -1,6 +1,6 @@
 import useCalculationStore from '@/store/calculationStore';
 import { UserIcon, CurrencyYenIcon } from "@heroicons/react/24/outline";
-import ShirtIcon from '../../ui/icon/ShirtIcon';
+import { ShirtIcon } from '../../ui/icon/ShirtIcon';
 import CustomersHoverCard from './CustomersHoverCard';
 
 export default function CurrentData() {
@@ -9,7 +9,6 @@ export default function CurrentData() {
   return (
     <>
       <div className="flex flex-row justify-center w-full">
-
         <div className="flex flex-col justify-center py-2 px-8">
           <UserIcon className="w-8 h-8 mx-auto text-gray-500"/>
           <p className="text-xs mx-auto text-gray-400">
@@ -24,7 +23,6 @@ export default function CurrentData() {
             </div>
           </div>
         </div>
-  
         <div className="flex flex-col justify-center py-2 px-8 border-l border-gray-200">
           <ShirtIcon className="w-8 h-8 mx-auto text-gray-500"/>
           <p className="flex text-xs mx-auto text-gray-400">
@@ -36,7 +34,6 @@ export default function CurrentData() {
             </h2>
           </div>
         </div>
-  
         <div className="flex flex-col justify-center py-2 px-8 border-l border-gray-200">
           <CurrencyYenIcon className="w-8 h-8 mx-auto text-gray-500"/>
           <p className="flex text-xs mx-auto text-gray-400">
@@ -48,7 +45,6 @@ export default function CurrentData() {
             </h2>
           </div>
         </div>
-
       </div>
     </>
   )

--- a/app/components/page/DashBoard/DayRecord.tsx
+++ b/app/components/page/DashBoard/DayRecord.tsx
@@ -1,6 +1,8 @@
 import { SalesRecord } from "@/types";
+import { formatCurrency } from "@/utils/currencyUtils";
 import {  CurrencyYenIcon } from "@heroicons/react/24/outline";
-import { ShoppingBagIcon,UserIcon } from "@heroicons/react/24/solid";
+import { ShoppingBagIcon,UserIcon,UsersIcon } from "@heroicons/react/24/solid";
+import { SolidShirtIcon } from "../../ui/icon/ShirtIcon";
 
 type DayRecordProps = {
   record: SalesRecord;
@@ -8,27 +10,37 @@ type DayRecordProps = {
 
 export default function DayRecord({ record }: DayRecordProps) {
 
-  const formatCurrency = (amount :number) => {
-    return new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(amount);
-  }
-
   return (
     <>
-      <div className="p-4 border-t">
-        <div className="mb-2 flex items-center text-gray-700">
-          <CurrencyYenIcon className="w-6 h-6 text-gray-500 mr-2" />
-          売上金額：
-          <span>{formatCurrency(record.total_amount)}</span>
+      <div className="px-5 pb-2">
+        <div className="flex items-center text-gray-700">
+          <CurrencyYenIcon className="w-6 h-6 text-sky-800 mr-2" />
+          売上金額
         </div>
-        <div className="mb-2 flex items-center text-gray-700">
-          <UserIcon className="w-6 h-6 text-gray-500 mr-2" />
-          客単価：
-          <span>{formatCurrency(record.average_spend)} （客数: {record.count}）</span>
+        <div className="py-1 ml-8 text-lg text-gray-700 font-bold">{formatCurrency(record.total_amount)}</div>
+        <div className="flex flex-row items-center text-gray-700 border-t mt-2 pt-3">
+          <UserIcon className="w-6 h-6 text-sky-800 mr-2" />
+          客単価
         </div>
-        <div className="mb-2 flex items-center text-gray-700">
-          <ShoppingBagIcon className="w-6 h-6 text-gray-500 mr-2" />
-          セット率：
-          <span>{record.set_rate} （点数: {record.total_number}）</span>
+        <div className="flex flex-row">
+          <div className="py-1 ml-8 text-gray-700 text-lg font-bold">{formatCurrency(record.average_spend)}</div>
+          <div className="flex flex-row items-center py-1 ml-8 text-lg font-bold text-gray-600">
+            <p className="px-4">/</p>
+            <div><UsersIcon  className="w-5 h-5 text-gray-600 mr-2"/></div>
+            <p>{record.total_number} 人</p>
+          </div>
+        </div>
+        <div className="flex items-center text-gray-700 border-t mt-2 pt-3">
+          <ShoppingBagIcon className="w-6 h-6 text-sky-800 mr-2"/>
+          セット率
+        </div>
+        <div className="flex flex-row">
+          <div className="py-1 ml-8 text-gray-700 text-lg font-bold">{record.set_rate.toFixed(1)}</div>
+          <div className="flex flex-row items-center py-1 ml-8 text-lg font-bold text-gray-600">
+            <p className="px-4">/</p>
+            <div><SolidShirtIcon className="w-5 h-5 text-gray-600 mr-2" /></div>
+            <p>{record.total_number} 点</p>
+          </div>
         </div>
       </div>
     </>

--- a/app/components/page/DashBoard/NotDayRecord.tsx
+++ b/app/components/page/DashBoard/NotDayRecord.tsx
@@ -1,10 +1,6 @@
-"use client"
-import { useRouter } from 'next/navigation'
-import { Button } from '@mantine/core';
-import { CursorArrowRaysIcon } from "@heroicons/react/24/solid";
+import RouterButton from "../../ui/button/RouterButton"
 
 export default function NotDayRecord() {
-  const router = useRouter()
   return (
     <>
       <div className="p-4 border-t">
@@ -12,10 +8,7 @@ export default function NotDayRecord() {
           <p>売上データがありません。</p>
           <p>売上を記録しますか？</p>
         </div>
-        <Button type="submit" variant="outline" color="gray" size="sm" onClick={() => router.push('/dairyrecord')}>
-          記録しにいく
-          <CursorArrowRaysIcon className="w-6 h-6 ml-1 text-blue-400" />
-        </Button>
+        <RouterButton size="sm" path="/dairyrecord">登録する</RouterButton>
       </div>
     </>
   )

--- a/app/components/page/DashBoard/ProgressArea.tsx
+++ b/app/components/page/DashBoard/ProgressArea.tsx
@@ -1,0 +1,34 @@
+import ThisWeek from './ThisWeek'
+import { ChartBarIcon, ChartPieIcon, BookOpenIcon } from "@heroicons/react/24/outline";
+
+export default function ProgressArea() {
+  return (
+    <>
+      <div className="flex flex-col w-full max-w-lg mb-3 pb-2">
+        <ThisWeek/>
+
+        <div className="flex flex-row justify-center items-center h-20 md:h-28 md:pb-3 md:mx-2 lg:mx-10">
+          <div className="w-1/3 mx-2">
+            <div className='flex flex-col justify-center items-center text-gray-400 hover:text-sky-700 p-5 md:p-6 bg-white shadow-md rounded-md hover:mt-1'>
+              <ChartPieIcon className="w-8 h-8"/>
+              <div className='text-xs text-gray-600 mt-1'>客層</div>
+            </div>
+          </div>
+          <div className="w-1/3 mx-2">
+          <div className='flex flex-col justify-center items-center text-gray-400 hover:text-sky-700 p-5 md:p-6 bg-white shadow-md rounded-md hover:mt-1'>
+              <ChartBarIcon className="w-8 h-8" />
+              <div className='text-xs text-gray-600 mt-1'>売上実績</div>
+            </div>
+          </div>
+          <div className="w-1/3 mx-2">
+          <div className='flex flex-col justify-center items-center text-gray-400 hover:text-sky-700 p-5 md:p-6 bg-white shadow-md rounded-md hover:mt-1'>
+              <BookOpenIcon className="w-8 h-8" />
+              <div className='text-xs text-gray-600 mt-1'>レポート</div>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </>
+  )
+}

--- a/app/components/page/DashBoard/SalesIndicator.tsx
+++ b/app/components/page/DashBoard/SalesIndicator.tsx
@@ -11,7 +11,7 @@ export default function SalesIndicator({ date, salesDates }:SalesIndicatorProps 
   const isSaleDay = salesDates.includes(dateString);
 
   return (
-    <Indicator size={6} color="#93c5fd" offset={-5} disabled={!isSaleDay}>
+    <Indicator size={6} color="#93c5fd" offset={-5} disabled={!isSaleDay} position="top-center">
       {date.getDate()}
     </Indicator>
   )

--- a/app/components/page/DashBoard/SalesModal.tsx
+++ b/app/components/page/DashBoard/SalesModal.tsx
@@ -1,8 +1,8 @@
+import { formatDateLayout } from '@/utils/dateUtils';
 import { SalesRecord } from '@/types';
 import { Modal } from '@mantine/core';
 import DayRecord from './DayRecord';
 import NotDayRecord from './NotDayRecord';
-import { formatDateLayout } from '@/utils/dateUtils';
 
 type SalesModalProps = {
     opened: boolean;
@@ -17,8 +17,8 @@ export default function SalesModal({ opened, close, selectedSalesRecord, selecte
     if (selectedDate) {
       return (
         <>
-          <div className='flex flex-row items-center w-full px-4 py-1 font-bold text-gray-500'>
-            {formatDateLayout(selectedDate)}
+          <div className='flex flex-row items-start w-full py-4 pr-20 mr-16 mb-1 pl-1 text-xl font-bold text-gray-700 border-b-8'>
+            <div className='flex w-full mr-12 ml-4'>{formatDateLayout(selectedDate)}</div>
           </div>
         </>
       );

--- a/app/components/page/DashBoard/ThisWeek.tsx
+++ b/app/components/page/DashBoard/ThisWeek.tsx
@@ -1,19 +1,35 @@
 'use client'
 import useDashboardStore from "@/store/dashboardStore";
+import WeeklyRingProgress from "./WeeklyRingProgress";
+import WeeklyProgress from "./WeeklyProgress";
+import { ForwardIcon } from "@heroicons/react/24/outline";
 
 export default function ThisWeek() {
 
+  const formatCurrency = (amount :number) => {
+    return new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(amount);
+  }
+
   const { thisWeekTarget, thisWeekAmount } = useDashboardStore();
-  const thisWeekProgress = useDashboardStore((state) => state.getThisWeekProgress());
+  const { progress, progressPercent } = useDashboardStore((state) => state.getThisWeekProgress());
+
+  const target = thisWeekTarget !== null ? thisWeekTarget / 10000 : 0;
+
     return (
       <>
-        <div className="flex flex-col justify-center items-center w-fll h-20 px-6">
-          <p>ダッシュボードです。アンニョン</p>
-          <h2>
-            今週の目標: {thisWeekTarget !== null ? thisWeekTarget : "まだ登録されていません"}
-          </h2>
-          <h2>現在の売上: {thisWeekAmount}</h2>
-          <h2>目標まであと: {thisWeekProgress}</h2>
+        <div className="flex flex-col justify-center items-center p-7">
+          <div className="flex flex-row items-center">
+            <WeeklyRingProgress value={progressPercent}/>
+            <WeeklyProgress target={target} amount={thisWeekAmount}/>
+          </div>
+          <div className="flex items-center text-md text-gray-700 mt-2">
+            <div className="flex flex-row items-end">
+              <ForwardIcon className="w-7 h-7 text-sky-800 mr-2" />
+              <div className="hidden md:block">目標達成まで残り... </div>
+              <div className="md:hidden">目標まで残り... </div>
+              <div className="text-2xl font-bold">{formatCurrency(progress)}</div>
+            </div>
+          </div>
         </div>
       </>
     );

--- a/app/components/page/DashBoard/WeeklyProgress.tsx
+++ b/app/components/page/DashBoard/WeeklyProgress.tsx
@@ -1,3 +1,4 @@
+import { formatCurrency } from "@/utils/currencyUtils";
 import RouterButton from "../../ui/button/RouterButton";
 import { ArrowTrendingUpIcon, FlagIcon } from "@heroicons/react/24/solid";
 
@@ -8,10 +9,6 @@ type WeeklyProgressProps = {
 
 export default function WeeklyProgress({ target, amount }:WeeklyProgressProps ) {
 
-  const formatCurrency = (amount :number) => {
-    return new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(amount);
-  }
-
   return (
     <>
       <div className="p-2">
@@ -20,7 +17,7 @@ export default function WeeklyProgress({ target, amount }:WeeklyProgressProps ) 
           今週の目標
         </div>
         {target !== 0 ? (
-          <div className="py-1 text-lg font-bold">￥{target}万</div>
+          <div className="py-1 ml-1 text-lg font-bold">￥{target}万</div>
         ) : (
           <div className="pt-2 pb-1 ml-1">
             <RouterButton size="xs" path="/weekly">登録する</RouterButton>

--- a/app/components/page/DashBoard/WeeklyProgress.tsx
+++ b/app/components/page/DashBoard/WeeklyProgress.tsx
@@ -1,0 +1,38 @@
+import RouterButton from "../../ui/button/RouterButton";
+import { ArrowTrendingUpIcon, FlagIcon } from "@heroicons/react/24/solid";
+
+type WeeklyProgressProps = {
+    target: number | null;
+    amount: number;
+};
+
+export default function WeeklyProgress({ target, amount }:WeeklyProgressProps ) {
+
+  const formatCurrency = (amount :number) => {
+    return new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(amount);
+  }
+
+  return (
+    <>
+      <div className="p-2">
+        <div className="flex items-center text-gray-700">
+          <FlagIcon className="w-6 h-6 text-sky-800 mr-2" />
+          今週の目標
+        </div>
+        {target !== 0 ? (
+          <div className="py-1 text-lg font-bold">￥{target}万</div>
+        ) : (
+          <div className="pt-2 pb-1 ml-1">
+            <RouterButton size="xs" path="/weekly">登録する</RouterButton>
+          </div>
+        )}
+        <div className="flex items-center text-gray-700 border-t mt-2 pt-2">
+          <ArrowTrendingUpIcon className="w-6 h-6 text-sky-800 mr-2" />
+          現在の売上
+        </div>
+        <div className="py-1 ml-1 text-lg font-bold text-sky-800">{formatCurrency(amount)}</div>
+      </div>
+    </>
+  )
+}
+  

--- a/app/components/page/DashBoard/WeeklyProgress.tsx
+++ b/app/components/page/DashBoard/WeeklyProgress.tsx
@@ -23,7 +23,7 @@ export default function WeeklyProgress({ target, amount }:WeeklyProgressProps ) 
             <RouterButton size="xs" path="/weekly">登録する</RouterButton>
           </div>
         )}
-        <div className="flex items-center text-gray-700 border-t mt-2 pt-2">
+        <div className="flex items-center text-gray-700 border-t-2 mt-2 pt-2">
           <ArrowTrendingUpIcon className="w-6 h-6 text-sky-800 mr-2" />
           現在の売上
         </div>

--- a/app/components/page/DashBoard/WeeklyRingProgress.tsx
+++ b/app/components/page/DashBoard/WeeklyRingProgress.tsx
@@ -1,0 +1,22 @@
+import { RingProgress, Text } from '@mantine/core';
+
+type RingProgressProps = {
+  value: number
+};
+
+export default function WeeklyRingProgress({value}:RingProgressProps) {
+  return (
+    <>
+      <RingProgress
+        sections={[{ value: value, color: '#93c5fd' }]}
+        thickness={17}
+        size={140}
+        label={
+          <Text c="blue" fw={700} ta="center" size="sm">
+            {value.toFixed(1)}%
+          </Text>
+        }
+      />
+  </>
+  )
+}

--- a/app/components/ui/button/RouterButton.tsx
+++ b/app/components/ui/button/RouterButton.tsx
@@ -1,0 +1,21 @@
+"use client"
+import { useRouter } from 'next/navigation'
+import { Button } from '@mantine/core';
+import { CursorArrowRaysIcon } from "@heroicons/react/24/solid";
+
+type RouterButtonProps = {
+    size: "xs" | "sm" | "md" | "lg" | "xl";
+    children: string;
+    path: string;
+}
+
+export default function RouterButton({ size, path, children }: RouterButtonProps) {
+  const router = useRouter()
+
+  return (
+    <Button size={size} variant="outline" color="#64748b" onClick={() => router.push(path)}>
+      {children}
+      <CursorArrowRaysIcon className="w-5 h-5 ml-1 text-blue-400" />
+    </Button>
+  )
+}

--- a/app/components/ui/icon/ShirtIcon.tsx
+++ b/app/components/ui/icon/ShirtIcon.tsx
@@ -2,7 +2,7 @@ type IconProps = {
   className?: string;
 };
 
-export default function ShirtIcon({ className }: IconProps ) {
+export function ShirtIcon({ className }: IconProps ) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" className={`icon icon-tabler icon-tabler-shirt ${className}`} width="44" height="44" viewBox="0 0 24 24" strokeWidth="1.5" stroke="#6b7280" fill="none" strokeLinecap="round" strokeLinejoin="round">
       <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
@@ -10,3 +10,13 @@ export default function ShirtIcon({ className }: IconProps ) {
     </svg>
   )
 }
+
+export function SolidShirtIcon({ className }: IconProps ) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" className={`icon icon-tabler icon-tabler-shirt ${className}`} width="44" height="44" viewBox="0 0 24 24" strokeWidth="1.5" stroke="#6b7280" fill="currentColor" strokeLinecap="round" strokeLinejoin="round">
+      <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+      <path d="M15 4l6 2v5h-3v8a1 1 0 0 1 -1 1h-10a1 1 0 0 1 -1 -1v-8h-3v-5l6 -2a3 3 0 0 0 6 0" />
+    </svg>
+  )
+}
+

--- a/types/index.ts
+++ b/types/index.ts
@@ -23,3 +23,8 @@ export type ResisteredDateRange = {
     startDate: string;
     endDate: string;
 };
+
+export type ProgressData = {
+    progress: number;
+    progressPercent: number;
+};

--- a/utils/currencyUtils.ts
+++ b/utils/currencyUtils.ts
@@ -1,0 +1,3 @@
+export const formatCurrency = (number :number) => {
+  return new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(number);
+}

--- a/utils/dateUtils.ts
+++ b/utils/dateUtils.ts
@@ -50,3 +50,10 @@ export const isDateInRanges = (date: Date, ranges: ResisteredDateRange[]): boole
     return checkDate.isAfter(startDate.subtract(1, 'day')) && checkDate.isBefore(endDate.add(1, 'day'));
   });
 };
+
+// 今週の開始日と終了日を取得する関数
+export const getThisWeekRange = () => {
+  const start = formatDate(getStartOfWeek(new Date()));
+  const end = formatDate(getEndOfWeek(new Date()));
+  return { start, end };
+};


### PR DESCRIPTION
## 概要

週間実績の目標に対するパーセンテージを算出し、RingProgressコンポーネントで表示。
issue: #36 

その他：
ダッシュボードに属するコンポーネントのレイアウト調整

## 変更点

- 上記概要に記載の内容変更
- ストア関数内で進捗率の算出を追加
- ダッシュボード→グラフコンテンツへの仮導線設置

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0

- ダッシュボードアクセス時に進捗に関する数値が反映されることを確認

## 影響範囲
- /dashboard

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応