### PR TITLE
Progress_3 #32

### DIFF
--- a/app/(authenticated)/dairyrecord/page.tsx
+++ b/app/(authenticated)/dairyrecord/page.tsx
@@ -4,7 +4,7 @@ import Submit from "@/app/components/page/DairyRecord/Submit";
 export default function DairyRecordPage() {
     return (
       <>
-      <div className="flex flex-col md:flex-row justify-center items-center mx-auto p-6 z-0 md:gap-x-6 max-w-5xl my-10">
+      <div className="flex flex-col md:flex-row justify-center items-center mx-auto px-6 z-0 md:gap-x-6 max-w-5xl my-10">
         <Caluculator/>
         <Submit/>
       </div>

--- a/app/(authenticated)/dashboard/page.tsx
+++ b/app/(authenticated)/dashboard/page.tsx
@@ -4,7 +4,7 @@ import ProgressArea from "@/app/components/page/DashBoard/ProgressArea";
 export default function Dashboard() {  
   return (
     <>
-    <div className="flex flex-col md:flex-row justify-center items-center mx-auto p-6 z-0 md:gap-x-6 max-w-5xl my-10">
+    <div className="flex flex-col md:flex-row justify-center items-center mx-auto px-6 z-0 md:gap-x-6 max-w-5xl my-10">
       <ProgressArea/>
       <CalenderArea/>
     </div>

--- a/app/(authenticated)/weekly/page.tsx
+++ b/app/(authenticated)/weekly/page.tsx
@@ -2,7 +2,7 @@ import StepForm from '@/app/components/page/StepForm/StepForm';
 
 export default function Weekly() {
   return (
-    <div className="flex flex-col justify-center items-center mx-auto p-6 z-0 my-10">
+    <div className="flex flex-col justify-center items-center mx-auto px-6 z-0 my-10">
       <StepForm />
     </div>
   );

--- a/app/components/page/DairyRecord/CurrentData.tsx
+++ b/app/components/page/DairyRecord/CurrentData.tsx
@@ -1,3 +1,4 @@
+import { formatCurrency } from "@/utils/currencyUtils";
 import useCalculationStore from '@/store/calculationStore';
 import { UserIcon, CurrencyYenIcon } from "@heroicons/react/24/outline";
 import { ShirtIcon } from '../../ui/icon/ShirtIcon';
@@ -8,14 +9,14 @@ export default function CurrentData() {
   
   return (
     <>
-      <div className="flex flex-row justify-center w-full">
-        <div className="flex flex-col justify-center py-2 px-8">
+      <div className="flex flex-row justify-center w-full overflow-auto">
+        <div className="flex flex-col justify-center py-2 px-6 lg:px-8">
           <UserIcon className="w-8 h-8 mx-auto text-gray-500"/>
           <p className="text-xs mx-auto text-gray-400">
             客数
           </p>
           <div className="flex flex-row items-center justify-center whitespace-nowrap mt-2 h-10">
-            <h2 className="title-font font-medium text-xl text-gray-600 mr-1">
+            <h2 className="title-font font-medium text-lg md:text-xl text-gray-600 mr-1">
               {count}
             </h2>
             <div className="md:hidden">
@@ -23,25 +24,25 @@ export default function CurrentData() {
             </div>
           </div>
         </div>
-        <div className="flex flex-col justify-center py-2 px-8 border-l border-gray-200">
+        <div className="flex flex-col justify-center py-2 px-6 lg:px-8 border-l border-gray-200">
           <ShirtIcon className="w-8 h-8 mx-auto text-gray-500"/>
           <p className="flex text-xs mx-auto text-gray-400">
             点数
           </p>
           <div className="flex flex-row items-center justify-center whitespace-nowrap mt-2 h-10">
-            <h2 className="title-font font-medium text-xl text-gray-600">
+            <h2 className="title-font font-medium text-lg md:text-xl text-gray-600">
               {totalNumber}
             </h2>
           </div>
         </div>
-        <div className="flex flex-col justify-center py-2 px-8 border-l border-gray-200">
+        <div className="flex flex-col justify-center py-2 px-6 lg:px-8 border-l border-gray-200">
           <CurrencyYenIcon className="w-8 h-8 mx-auto text-gray-500"/>
           <p className="flex text-xs mx-auto text-gray-400">
             金額
           </p>
           <div className="flex flex-row items-center justify-center whitespace-nowrap mt-2 h-10">
-            <h2 className="title-font font-medium text-xl text-gray-600">
-              {totalAmount}
+            <h2 className="title-font font-medium text-lg md:text-xl text-gray-600">
+              {formatCurrency(totalAmount)}
             </h2>
           </div>
         </div>

--- a/app/components/page/DairyRecord/CurrentDate.tsx
+++ b/app/components/page/DairyRecord/CurrentDate.tsx
@@ -1,6 +1,6 @@
 import useCalculationStore from '@/store/calculationStore';
-import { FlagIcon } from "@heroicons/react/24/solid";
 import { formatDateLayout } from '@/utils/dateUtils';
+import { CalendarIcon } from "@heroicons/react/24/outline";
 
 export default function CurrentDate() {
   const { selectedDate } = useCalculationStore();
@@ -9,8 +9,10 @@ export default function CurrentDate() {
 
   return (
     <div className="flex flex-row justify-center items-center w-full">
-        <FlagIcon className="w-5 h-5 text-gray-500 mr-2"/>
-        { formattedSelectedDate }
+      <div className="flex flex-row items-center border-b-4 border-gray-100 p-1">
+        <CalendarIcon className="w-6 h-6 text-gray-500 mr-2 ml-4"/>
+        <div className='text-lg mr-4'>{ formattedSelectedDate }</div>
+      </div>
     </div>
   )
 }

--- a/app/components/page/DairyRecord/CustomersHoverCard.tsx
+++ b/app/components/page/DairyRecord/CustomersHoverCard.tsx
@@ -1,4 +1,4 @@
-import { HoverCard, Text, Group, Avatar } from '@mantine/core';
+import { HoverCard, Text, Group, ActionIcon  } from '@mantine/core';
 import { UsersIcon } from "@heroicons/react/24/outline";
 import CustomersList from './CustomersList';
 
@@ -7,9 +7,9 @@ export default function CustomersHoverCard() {
     <Group justify="center">
       <HoverCard width={280} shadow="md">
         <HoverCard.Target>
-          <Avatar color="blue" radius="xl">
-            <UsersIcon  className="w-5 h-5" />
-          </Avatar>
+          <ActionIcon variant="light" size="lg" color="#60a5fa" radius="xl" aria-label="Settings" className="shadow-md hover:mt-1">
+            <UsersIcon className="w-10 h-10 m-1 p-1"/>
+          </ActionIcon>
         </HoverCard.Target>
         <HoverCard.Dropdown>
           <Text size="xs">

--- a/app/components/page/DairyRecord/CustomersList.tsx
+++ b/app/components/page/DairyRecord/CustomersList.tsx
@@ -6,7 +6,7 @@ export default function CustomersList() {
   const { customerLabels } = useCalculationStore();
 
   return (
-    <div className="flex flex-row justify-center items-center w-fll h-20 px-6">
+    <div className="flex flex-row justify-center items-center w-full h-20 px-6">
       {customerLabels.length > 0 ? (
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-2 w-full">
           {customerLabels.split('、').map((label, index) => (

--- a/app/components/page/DashBoard/CalenderArea.tsx
+++ b/app/components/page/DashBoard/CalenderArea.tsx
@@ -2,7 +2,7 @@ import Calender from "./Calendar"
 
 export default function CalenderArea() {
   return (
-    <div className="bg-white p-7 shadow-md flex flex-col">
+    <div className="bg-white p-7 shadow-md rounded-md flex flex-col">
       <div className="flex flex-row justify-end items-center w-full text-gray-400 px-2 mb-2">
         <span className="text-xs text-blue-300 mr-1">⚫︎</span>
         <span className="text-xs">売上記録した日</span>

--- a/app/components/page/DashBoard/DayRecord.tsx
+++ b/app/components/page/DashBoard/DayRecord.tsx
@@ -12,7 +12,7 @@ export default function DayRecord({ record }: DayRecordProps) {
 
   return (
     <>
-      <div className="px-5 pb-2">
+      <div className="p-4 border-t-8">
         <div className="flex items-center text-gray-700">
           <CurrencyYenIcon className="w-6 h-6 text-sky-800 mr-2" />
           売上金額

--- a/app/components/page/DashBoard/DayRecord.tsx
+++ b/app/components/page/DashBoard/DayRecord.tsx
@@ -27,7 +27,7 @@ export default function DayRecord({ record }: DayRecordProps) {
           <div className="flex flex-row items-center py-1 ml-8 text-lg font-bold text-gray-600">
             <p className="px-4">/</p>
             <div><UsersIcon  className="w-5 h-5 text-gray-600 mr-2"/></div>
-            <p>{record.total_number} 人</p>
+            <p>{record.count} 人</p>
           </div>
         </div>
         <div className="flex items-center text-gray-700 border-t mt-2 pt-3">

--- a/app/components/page/DashBoard/NotDayRecord.tsx
+++ b/app/components/page/DashBoard/NotDayRecord.tsx
@@ -6,7 +6,7 @@ export default function NotDayRecord() {
       <div className="p-4 border-t-8">
         <div className="mb-2">
           <p>売上データがありません。</p>
-          <p>売上を記録しますか？</p>
+          <p>売上を登録しますか？</p>
         </div>
         <RouterButton size="sm" path="/dairyrecord">登録する</RouterButton>
       </div>

--- a/app/components/page/DashBoard/NotDayRecord.tsx
+++ b/app/components/page/DashBoard/NotDayRecord.tsx
@@ -3,7 +3,7 @@ import RouterButton from "../../ui/button/RouterButton"
 export default function NotDayRecord() {
   return (
     <>
-      <div className="p-4 border-t">
+      <div className="p-4 border-t-8">
         <div className="mb-2">
           <p>売上データがありません。</p>
           <p>売上を記録しますか？</p>

--- a/app/components/page/DashBoard/SalesModal.tsx
+++ b/app/components/page/DashBoard/SalesModal.tsx
@@ -17,7 +17,7 @@ export default function SalesModal({ opened, close, selectedSalesRecord, selecte
     if (selectedDate) {
       return (
         <>
-          <div className='flex flex-row items-start w-full py-4 pr-20 mr-16 mb-1 pl-1 text-xl font-bold text-gray-700 border-b-8'>
+          <div className='flex flex-row items-start w-full pt-4 pr-22 mr-16 mb-1 pl-1 text-xl font-bold text-gray-700'>
             <div className='flex w-full mr-12 ml-4'>{formatDateLayout(selectedDate)}</div>
           </div>
         </>

--- a/app/components/page/DashBoard/ThisWeek.tsx
+++ b/app/components/page/DashBoard/ThisWeek.tsx
@@ -22,9 +22,9 @@ export default function ThisWeek() {
             <WeeklyRingProgress value={progressPercent}/>
             <WeeklyProgress target={target} amount={thisWeekAmount}/>
           </div>
-          <div className="flex items-center text-md text-gray-700 mt-2">
+          <div className="flex items-end text-md text-gray-700 mt-2">
             <div className="flex flex-row items-end">
-              <ForwardIcon className="w-7 h-7 text-sky-800 mr-2" />
+              <ForwardIcon className="w-8 h-8 text-sky-800 mr-2"/>
               <div className="hidden md:block">目標達成まで残り... </div>
               <div className="md:hidden">目標まで残り... </div>
               <div className="text-2xl font-bold">{formatCurrency(progress)}</div>

--- a/app/components/page/DashBoard/ThisWeek.tsx
+++ b/app/components/page/DashBoard/ThisWeek.tsx
@@ -24,7 +24,11 @@ export default function ThisWeek() {
               <ForwardIcon className="w-8 h-8 text-sky-800 mr-2"/>
               <div className="hidden md:block">目標達成まで残り... </div>
               <div className="md:hidden">目標まで残り... </div>
-              <div className="text-2xl font-bold">{formatCurrency(progress)}</div>
+              {progress < 0 ? (
+                <div className="text-2xl font-bold">{formatCurrency(0)}</div>
+              ) : (
+                <div className="text-2xl font-bold">{formatCurrency(progress)}</div>
+              )}
             </div>
           </div>
         </div>

--- a/app/components/page/DashBoard/ThisWeek.tsx
+++ b/app/components/page/DashBoard/ThisWeek.tsx
@@ -1,14 +1,11 @@
 'use client'
+import { formatCurrency } from "@/utils/currencyUtils";
 import useDashboardStore from "@/store/dashboardStore";
 import WeeklyRingProgress from "./WeeklyRingProgress";
 import WeeklyProgress from "./WeeklyProgress";
 import { ForwardIcon } from "@heroicons/react/24/outline";
 
 export default function ThisWeek() {
-
-  const formatCurrency = (amount :number) => {
-    return new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(amount);
-  }
 
   const { thisWeekTarget, thisWeekAmount } = useDashboardStore();
   const { progress, progressPercent } = useDashboardStore((state) => state.getThisWeekProgress());

--- a/app/components/page/StepForm/Achievements.tsx
+++ b/app/components/page/StepForm/Achievements.tsx
@@ -1,0 +1,39 @@
+'use client'
+import useDashboardStore from "@/store/dashboardStore";
+import WeekRecordHoverCard from '../WeeklyReport.tsx/WeekRecordHover';
+
+export default function Achievements() {
+
+  const { progress, progressPercent } = useDashboardStore((state) => state.getThisWeekProgress());
+
+  return (
+    <div className="flex space-y-3 w-full mx-auto">
+    <div className="flex w-full p-2 mx-auto justify-start md:justify-center">
+      <div className='flex flex-col md:flex-row w-60 md:w-full h-18 md:h-10 items-start md:items-center'>
+        
+        <div className='flex flex-row items-center text-sm text-gray-700'>
+          <div className="mr-1">
+            予算達成率:
+          </div>
+          <div className="text-lg font-bold text-sky-800">
+            {progressPercent.toFixed(1)}
+          </div>
+          <div className="mr-3 ml-1">
+            %
+          </div>
+        </div>
+
+        <div className='flex flex-row items-center text-sm text-gray-700'>
+          <div className="md:pl-2 md:border-l border-gray-400">
+            詳しい実績を見る
+          </div>
+          <div className="ml-2">
+            <WeekRecordHoverCard />
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+  )
+}

--- a/app/components/page/StepForm/Achievements.tsx
+++ b/app/components/page/StepForm/Achievements.tsx
@@ -1,43 +1,71 @@
 'use client'
+import { getThisWeekRange, formatDateMD } from "@/utils/dateUtils";
 import useDashboardStore from "@/store/dashboardStore";
-import WeekRecordHoverCard from '../WeeklyReport.tsx/WeekRecordHover';
+import { useDisclosure } from '@mantine/hooks';
+import { ActionIcon, Modal } from '@mantine/core';
 import { CursorArrowRaysIcon } from "@heroicons/react/24/solid";
-import { ActionIcon, Button } from '@mantine/core';
+import { CalendarIcon } from "@heroicons/react/24/outline";
+import AchievementsDetail from "./AchievementsDetail";
 
 export default function Achievements() {
 
-  const { progress, progressPercent } = useDashboardStore((state) => state.getThisWeekProgress());
+  const { thisWeekTarget, thisWeekAmount, thisWeekNumber, thisWeekCount, thisWeekSet, thisWeekAverage } = useDashboardStore();
+  const { progressPercent, progress } = useDashboardStore((state) => state.getThisWeekProgress());
+  const [opened, { open, close }] = useDisclosure(false);
+  const modalTitle = () => {
+    const { start, end } = getThisWeekRange();
+      return (
+        <>
+          <div className='flex flex-row items-start w-full pt-4 pr-22 mr-16 pl-1 text-xl font-bold text-gray-700'>
+            <div className='flex w-full mr-12 ml-4 items-center'>
+              <CalendarIcon className="w-8 h-8 text-sky-800 mr-2" />
+              {formatDateMD(start)} 〜 {formatDateMD(end)}
+            </div>
+          </div>
+        </>
+      );
+  };
 
   return (
     <div className="flex space-y-3 w-full mx-auto">
-    <div className="flex w-full p-2 mx-auto justify-start md:justify-center">
-      <div className='flex flex-col md:flex-row w-60 md:w-full h-18 md:h-10 items-start md:items-center'>
-        
-        <div className='flex flex-row items-center text-sm text-gray-700'>
-          <div className="mr-1">
-            予算達成率:
+      <div className="flex w-full p-2 mx-auto justify-start md:justify-center">
+        <div className='flex flex-col md:flex-row w-60 md:w-full h-18 md:h-10 items-start md:items-center'>     
+          <div className='flex flex-row items-center text-sm text-gray-700'>
+            <div className="mr-1">今週の目標達成率:</div>
+            <div className="text-lg font-bold text-blue-400">
+              {progressPercent.toFixed(1)}
+            </div>
+            <div className="mr-3 ml-1">%</div>
           </div>
-          <div className="text-lg font-bold text-blue-400">
-            {progressPercent.toFixed(1)}
-          </div>
-          <div className="mr-3 ml-1">
-            %
+          <div className='flex flex-row items-center text-sm text-gray-700'>
+            <div className="md:pl-2 md:border-l border-gray-400">詳しい実績をみる</div>
+            <div className="ml-2">
+              <ActionIcon
+                variant="white"
+                size="lg"
+                color="#60a5fa"
+                aria-label="Settings" 
+                className="shadow-md hover:mt-1 hover:text-sky-700"
+                onClick={open}
+              >
+                <CursorArrowRaysIcon className="w-8 h-8 p-1"/>
+              </ActionIcon>
+            </div>
           </div>
         </div>
-
-        <div className='flex flex-row items-center text-sm text-gray-700'>
-          <div className="md:pl-2 md:border-l border-gray-400">
-            詳しい実績を見る
-          </div>
-          <div className="ml-2">
-            <ActionIcon variant="white" size="lg" color="#60a5fa" aria-label="Settings" className="shadow-md hover:mt-1">
-              <CursorArrowRaysIcon className="w-8 h-8 p-1"/>
-            </ActionIcon>
-          </div>
-        </div>
-
       </div>
+      <Modal opened={opened} onClose={close} title={modalTitle()} centered >
+        <AchievementsDetail
+          target={thisWeekTarget}
+          amount={thisWeekAmount}
+          number={thisWeekNumber}
+          count={thisWeekCount}
+          set={thisWeekSet}
+          average={thisWeekAverage}
+          progressPercent={progressPercent}
+          progress={progress}
+        />
+      </Modal>
     </div>
-  </div>
   )
 }

--- a/app/components/page/StepForm/Achievements.tsx
+++ b/app/components/page/StepForm/Achievements.tsx
@@ -1,6 +1,8 @@
 'use client'
 import useDashboardStore from "@/store/dashboardStore";
 import WeekRecordHoverCard from '../WeeklyReport.tsx/WeekRecordHover';
+import { CursorArrowRaysIcon } from "@heroicons/react/24/solid";
+import { ActionIcon, Button } from '@mantine/core';
 
 export default function Achievements() {
 
@@ -15,7 +17,7 @@ export default function Achievements() {
           <div className="mr-1">
             予算達成率:
           </div>
-          <div className="text-lg font-bold text-sky-800">
+          <div className="text-lg font-bold text-blue-400">
             {progressPercent.toFixed(1)}
           </div>
           <div className="mr-3 ml-1">
@@ -28,7 +30,9 @@ export default function Achievements() {
             詳しい実績を見る
           </div>
           <div className="ml-2">
-            <WeekRecordHoverCard />
+            <ActionIcon variant="white" size="lg" color="#60a5fa" aria-label="Settings" className="shadow-md hover:mt-1">
+              <CursorArrowRaysIcon className="w-8 h-8 p-1"/>
+            </ActionIcon>
           </div>
         </div>
 

--- a/app/components/page/StepForm/AchievementsDetail.tsx
+++ b/app/components/page/StepForm/AchievementsDetail.tsx
@@ -1,0 +1,77 @@
+import { formatCurrency } from "@/utils/currencyUtils";
+import { CurrencyYenIcon } from "@heroicons/react/24/outline";
+import { ShoppingBagIcon,UserIcon,UsersIcon, FlagIcon, PlusIcon, MinusIcon } from "@heroicons/react/24/solid";
+import { SolidShirtIcon } from "../../ui/icon/ShirtIcon";
+
+type AchievementsDetailProps = {
+  target: number | null;
+  amount: number;
+  number: number;
+  count: number;
+  set: number;
+  average: number;
+  progressPercent: number;
+  progress: number;
+};
+
+export default function AchievementsDetail({amount, number, count, set, average, progressPercent, progress} :AchievementsDetailProps) {
+
+  return (
+    <div className="p-4 border-t-8"> 
+      <div className="flex flex-row items-center text-gray-700">
+        <FlagIcon className="w-6 h-6 text-sky-800 mr-2" />
+        目標達成率
+      </div>
+      <div className="flex flex-row">
+        {progressPercent >= 100 ? (
+          <div className="py-1 ml-8 text-blue-400 text-lg font-bold">{progressPercent.toFixed(1)}%</div>
+        ) : (
+          <div className="py-1 ml-8 text-red-400 text-lg font-bold">{progressPercent.toFixed(1)}%</div>
+        )}
+        <div className="flex flex-row items-center py-1 ml-8 text-lg font-bold text-gray-600">
+          <p className="px-4">/</p>
+          {progress < 0 ? (
+            <>
+              <div><PlusIcon className="w-5 h-5 text-blue-400"/></div>
+              <p>{formatCurrency(Math.abs(progress))}</p>
+            </>
+          ) : (
+            <>
+              <div><MinusIcon className="w-5 h-5 text-red-400 mr-1"/></div>
+              <p>{formatCurrency(progress)}</p>
+            </>
+          )}
+        </div>
+      </div>
+      <div className="flex items-center text-gray-700 border-t mt-2 pt-3">
+        <CurrencyYenIcon className="w-6 h-6 text-sky-800 mr-2" />
+        売上金額
+      </div>
+      <div className="py-1 ml-8 text-lg text-gray-700 font-bold">{formatCurrency(amount)}</div>
+        <div className="flex flex-row items-center text-gray-700 border-t mt-2 pt-3">
+          <UserIcon className="w-6 h-6 text-sky-800 mr-2" />
+          客単価
+      </div>
+      <div className="flex flex-row">
+        <div className="py-1 ml-8 text-gray-700 text-lg font-bold">{formatCurrency(average)}</div>
+        <div className="flex flex-row items-center py-1 ml-8 text-lg font-bold text-gray-600">
+          <p className="px-4">/</p>
+          <div><UsersIcon  className="w-5 h-5 text-gray-600 mr-2"/></div>
+          <p>{count}人</p>
+        </div>
+      </div>
+      <div className="flex items-center text-gray-700 border-t mt-2 pt-3">
+        <ShoppingBagIcon className="w-6 h-6 text-sky-800 mr-2"/>
+        セット率
+      </div>
+      <div className="flex flex-row">
+        <div className="py-1 ml-8 text-gray-700 text-lg font-bold">{set.toFixed(1)}</div>
+        <div className="flex flex-row items-center py-1 ml-8 text-lg font-bold text-gray-600">
+          <p className="px-4">/</p>
+          <div><SolidShirtIcon className="w-5 h-5 text-gray-600 mr-2" /></div>
+          <p>{number}点</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/components/page/StepForm/Report.tsx
+++ b/app/components/page/StepForm/Report.tsx
@@ -2,6 +2,7 @@ import ReportRangeInput from '../WeeklyReport.tsx/RepotRangeInput';
 import ReportInputForm from '../WeeklyReport.tsx/ReportInput';
 import WeekRecordHoverCard from '../WeeklyReport.tsx/WeekRecordHover';
 import { PencilIcon } from '@heroicons/react/24/outline';
+import Achievements from './Achievements';
 
 export default function Report() {
   return (
@@ -16,34 +17,7 @@ export default function Report() {
         <ReportRangeInput />
       </div>
 
-      <div className="flex space-y-3 w-full mx-auto">
-        <div className="flex w-full p-2 mx-auto justify-start md:justify-center">
-          <div className='flex flex-col md:flex-row w-60 md:w-full h-18 md:h-10 items-start md:items-center'>
-            
-            <div className='flex flex-row items-center text-sm text-gray-700'>
-              <div className="mr-1">
-                予算達成率:
-              </div>
-              <div className="text-lg text-gray-800">
-                100
-              </div>
-              <div className="mr-3 ml-1">
-                %
-              </div>
-            </div>
-
-            <div className='flex flex-row items-center text-sm text-gray-700'>
-              <div className="md:pl-2 md:border-l border-gray-400">
-                詳しい実績を見る
-              </div>
-              <div className="ml-2">
-                <WeekRecordHoverCard />
-              </div>
-            </div>
-
-          </div>
-        </div>
-      </div>
+      <Achievements/>
 
       <div className="flex flex-row justify-center items-center w-full">
         <div className="flex w-full p-2 mx-aut justify-center">

--- a/app/components/page/StepForm/StepperIcon.tsx
+++ b/app/components/page/StepForm/StepperIcon.tsx
@@ -5,7 +5,7 @@ export default function StepperIcon({ active } :any) {
   return (
     <>
       <div className="pb-5 px-5 md:hidden">
-        <Stepper active={active} size="xs" color='#60a5fa'>
+        <Stepper active={active} size="xs" color='#93c5fd'>
           <Stepper.Step  />
           <Stepper.Step  />
           <Stepper.Step  />
@@ -15,7 +15,7 @@ export default function StepperIcon({ active } :any) {
       <div className="p-4 mb-2 hidden md:block">
         <Stepper
           active={active}
-          color='#60a5fa'
+          color='#93c5fd'
           size="md"
         >
           <Stepper.Step

--- a/app/components/ui/button/BackButton.tsx
+++ b/app/components/ui/button/BackButton.tsx
@@ -9,7 +9,7 @@ type BackButtonProps = {
 
 export default function BackButton({ size, type, onClick }: BackButtonProps) {
   return (
-    <Button size={size} type={type} variant="outline" color="#9ca3af" onClick={onClick}>
+    <Button size={size} type={type} variant="outline" color="#9ca3af" onClick={onClick} className='hover:shadow-md'>
       <ChevronDoubleLeftIcon className="w-5 h-5 mr-2 text-gray-600" />
       戻る
     </Button>

--- a/app/components/ui/button/ClearButton.tsx
+++ b/app/components/ui/button/ClearButton.tsx
@@ -11,7 +11,7 @@ export default function ClearButton({ size, type, onClick }: ClearButtonProps) {
   return (
     <Button size={size} type={type} variant="outline" color="#9ca3af" onClick={onClick}>
       クリア
-      <XCircleIcon className="w-5 h-5 ml-1 text-red-400" />
+      <XCircleIcon className="w-5 h-5 ml-1" />
     </Button>
   )
 }

--- a/app/components/ui/button/NextButton.tsx
+++ b/app/components/ui/button/NextButton.tsx
@@ -9,9 +9,9 @@ type NextButtonProps = {
 
 export default function NextButton({ size, type, onClick }: NextButtonProps) {
   return (
-    <Button size={size} type={type} variant="outline" color="#9ca3af" onClick={onClick}>
+    <Button size={size} type={type} variant="filled" color="#93c5fd" onClick={onClick} className='hover:shadow-md'>
       次へ
-      <ChevronDoubleRightIcon className="w-5 h-5 ml-2 text-blue-400" />
+      <ChevronDoubleRightIcon className="w-5 h-5 ml-2" />
     </Button>
   )
 }

--- a/app/components/ui/button/SkipButton.tsx
+++ b/app/components/ui/button/SkipButton.tsx
@@ -10,9 +10,9 @@ type SkipButtonProps = {
 
 export default function SkipButton({ size, type, onClick, children }: SkipButtonProps) {
   return (
-    <Button size={size} type={type} variant="outline" color="#9ca3af" onClick={onClick}>
+    <Button size={size} type={type} variant="outline" color="#9ca3af" onClick={onClick} className='hover:shadow-md'>
       {children}
-      <ForwardIcon className="w-5 h-5 ml-2 text-yellow-300" />
+      <ForwardIcon className="w-6 h-6 ml-2 text-blue-300" />
     </Button>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,12 +19,12 @@ export default function RootLayout({
       <body className='bg-gray-100'>
         <NextAuthProvider>
           <MantineProviderWrapper>
-          <div className="flex flex-col h-screen">
-            <Header />
-            <main className="flex-grow">
-            {children}
-            </main>
-            <Footer />
+            <div className="flex flex-col h-screen">
+              <Header />
+              <main>
+                {children}
+              </main>
+              <Footer />
             </div>
           </MantineProviderWrapper>
         </NextAuthProvider>

--- a/store/dashboardStore.ts
+++ b/store/dashboardStore.ts
@@ -11,8 +11,12 @@ type DashboardState = {
   weeklyTargets: WeeklyTarget[];
   registeredTargetRanges: ResisteredDateRange[];
   thisWeekRecord: SalesRecord[];
-  thisWeekTarget: number | null;
   thisWeekAmount: number;
+  thisWeekNumber: number;
+  thisWeekCount: number;
+  thisWeekTarget: number | null;
+  thisWeekSet: number;
+  thisWeekAverage: number;
   fetchSalesRecord: (userId: number, force?: boolean) => Promise<void>;
   fetchWeeklyReport: (userId: number, force?: boolean) => Promise<void>;
   fetchWeeklyTarget: (userId: number, force?: boolean) => Promise<void>;
@@ -29,7 +33,11 @@ const useDashboardStore = create<DashboardState>((set, get) => ({
   registeredTargetRanges: [], // 登録した目標の日付データ
   thisWeekRecord: [],
   thisWeekAmount: 0,
+  thisWeekNumber: 0,
+  thisWeekCount: 0,
   thisWeekTarget: 0,
+  thisWeekSet: 0,
+  thisWeekAverage: 0,
 
   fetchSalesRecord: async (userId, force = false) => {
     if (force || get().lastFetchedUserId !== userId || get().salesRecords.length === 0) {
@@ -42,12 +50,20 @@ const useDashboardStore = create<DashboardState>((set, get) => ({
           record.date >= start && record.date <= end
         );
         const thisWeekAmount = thisWeekRecord.reduce((sum, record) => sum + record.total_amount, 0);
+        const thisWeekNumber = thisWeekRecord.reduce((sum, record) => sum + record.total_number, 0);
+        const thisWeekCount = thisWeekRecord.reduce((sum, record) => sum + record.count, 0);
+        const thisWeekSet = thisWeekCount > 0 ? thisWeekNumber / thisWeekCount : 0;
+        const thisWeekAverage = thisWeekCount > 0 ? thisWeekAmount / thisWeekCount : 0;
         set({
           salesRecords: data, 
           salesDates: dates, 
           lastFetchedUserId: userId,
           thisWeekRecord,
           thisWeekAmount,
+          thisWeekNumber,
+          thisWeekCount,
+          thisWeekSet,
+          thisWeekAverage,
         });
       } catch (error) {
         console.error("Failed to fetch", error);
@@ -100,7 +116,7 @@ const useDashboardStore = create<DashboardState>((set, get) => ({
     const progress = thisWeekTarget > 0 ? thisWeekTarget - thisWeekAmount : 0;
     const progressPercent = thisWeekTarget > 0 ? (thisWeekAmount / thisWeekTarget) * 100 : 0;
     return {
-      progress: progress >= 0 ? progress : 0, // 目標を超えた場合は 0 を返す
+      progress,
       progressPercent
     };
   },


### PR DESCRIPTION
## 概要

ステップ入力ページのレポート入力画面で今週の実績を確認できるエリアを作成
issue: #32 

その他：
ダッシュボードモーダル内の数値を修正
レイアウト調整

## 変更点

- ストア内関数で今週の客数, 点数, セット率, 客単価のセットを追加
- 上記を利用した今週の実績を表示するモーダルコンテンツをレポート入力画面で表示
- ページ全体の余白、ボタンなどのレイアウト修正

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0

- モーダル内に今週の実績が反映されることを確認

## 影響範囲
- /dashboard
- /daityrecord
- /weekly

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応

## コメント
実績確認できるのは”今週のみ”