### PR TITLE
CreateThisWeekTarget #35

### DIFF
--- a/app/(authenticated)/dairyrecord/page.tsx
+++ b/app/(authenticated)/dairyrecord/page.tsx
@@ -4,10 +4,10 @@ import Submit from "@/app/components/page/DairyRecord/Submit";
 export default function DairyRecordPage() {
     return (
       <>
-      <div className="flex flex-col md:flex-row justify-center items-center mx-auto px-6 z-0 md:gap-x-6 max-w-5xl my-10 md:my-20">
-        <Caluculator/>
-        <Submit/>
-      </div>
+        <div className="flex flex-col md:flex-row justify-center items-center mx-auto px-6 z-0 md:gap-x-6 max-w-4xl my-10 xl:my-20">
+          <Caluculator/>
+          <Submit/>
+        </div>
       </>
     )
 }

--- a/app/(authenticated)/dashboard/page.tsx
+++ b/app/(authenticated)/dashboard/page.tsx
@@ -4,7 +4,7 @@ import ProgressArea from "@/app/components/page/DashBoard/ProgressArea";
 export default function Dashboard() {  
   return (
     <>
-    <div className="flex flex-col md:flex-row justify-center items-center mx-auto px-6 z-0 md:gap-x-6 max-w-5xl my-10 md:my-20">
+    <div className="flex flex-col md:flex-row justify-center items-center mx-auto px-6 z-0 md:gap-x-6 max-w-5xl my-10 xl:my-20">
       <ProgressArea/>
       <CalenderArea/>
     </div>

--- a/app/(authenticated)/weekly/page.tsx
+++ b/app/(authenticated)/weekly/page.tsx
@@ -2,7 +2,7 @@ import StepForm from '@/app/components/page/StepForm/StepForm';
 
 export default function Weekly() {
   return (
-    <div className="flex flex-col justify-center items-center mx-auto px-6 z-0 my-10 md:my-20">
+    <div className="flex flex-col justify-center items-center mx-auto px-6 z-0 my-10 xl:my-20">
       <StepForm />
     </div>
   );

--- a/app/components/base/BurgerIcon.tsx
+++ b/app/components/base/BurgerIcon.tsx
@@ -7,6 +7,6 @@ type DrawerOpenProps = {
 
 export default function BurgerIcon({ open }: DrawerOpenProps) {
   return (
-    <Burger onClick={open} className="w-6 h-6 md:hidden mr-2"/>
+    <Burger onClick={open} className="w-6 h-6 mr-2"/>
   )
 }

--- a/app/components/base/BurgerIcon.tsx
+++ b/app/components/base/BurgerIcon.tsx
@@ -7,6 +7,6 @@ type DrawerOpenProps = {
 
 export default function BurgerIcon({ open }: DrawerOpenProps) {
   return (
-    <Burger onClick={open} className="w-6 h-6 mr-2"/>
+    <Burger onClick={open} className="w-6 h-6 mr-2 ml-1 md:ml-4"/>
   )
 }

--- a/app/components/base/DrawerMenu.tsx
+++ b/app/components/base/DrawerMenu.tsx
@@ -7,14 +7,14 @@ import BurgerIcon from './BurgerIcon';
 import DrawerContents from './DrawerContents';
 
 export default function DrawerMenu() {
-  const { data: session, status } = useSession();
+  const { data: session } = useSession();
   const [opened, { open, close }] = useDisclosure(false);
   const [active, setActive] = useState(0); 
 
   if(session)
     return (
       <>
-        <Drawer opened={opened} onClose={close} size="xs">
+        <Drawer opened={opened} onClose={close} size="md">
           <DrawerContents active={active} setActive={setActive} onClose={close}/>
         </Drawer >
   

--- a/app/components/base/DrawerMenu.tsx
+++ b/app/components/base/DrawerMenu.tsx
@@ -14,7 +14,7 @@ export default function DrawerMenu() {
   if(session)
     return (
       <>
-        <Drawer opened={opened} onClose={close} size="md">
+        <Drawer opened={opened} onClose={close} size="xs">
           <DrawerContents active={active} setActive={setActive} onClose={close}/>
         </Drawer >
   

--- a/app/components/base/Header.tsx
+++ b/app/components/base/Header.tsx
@@ -5,9 +5,9 @@ import DrawerMenu from "./DrawerMenu";
 export default function Header() {
   return (
     <header className="sticky top-0 text-gray-600 body-font bg-white z-50">
-      <div className="container mx-auto flex flex-wrap p-6 items-center justify-between md:max-w-5xl">
+      <div className="container mx-auto flex flex-wrap p-5 items-center justify-between md:max-w-3xl">
         <div className="flex items-center">
-        <span className="md:hidden"><DrawerMenu/></span>
+          <span className=""><DrawerMenu/></span>
           <div className="flex items-center">
             <span className="mx-1 text-xl font-bold">sales buddy</span>
             <CloudIcon className="w-6 h-6 font-bold" />

--- a/app/components/base/HeaderMenu.tsx
+++ b/app/components/base/HeaderMenu.tsx
@@ -6,7 +6,7 @@ export default function HeaderMenu() {
   const router = useRouter();
   return (
     <>
-      <nav className="hidden md:flex md:mr-auto md:ml-4 md:py-1 md:pl-4 md:border-l md:border-gray-400 flex-wrap items-center text-base justify-center">
+      {/* <nav className="hidden md:flex md:mr-auto md:ml-4 md:py-1 md:pl-4 md:border-l md:border-gray-400 flex-wrap items-center text-base justify-center">
         {headerNavigationItems.map((item, index) => (
           <a
             key={index}
@@ -17,7 +17,7 @@ export default function HeaderMenu() {
             {item.label}
           </a>
         ))}
-      </nav>
+      </nav> */}
     </>
   )
 }

--- a/app/components/base/UserStatus.tsx
+++ b/app/components/base/UserStatus.tsx
@@ -13,13 +13,13 @@ export default function UserStatus () {
   }
 
   return session ? (
-    <>
-    <HeaderMenu />
-    <ProfileDropdown
-      image={session.user.image} 
-      name={session.user.name} 
-    />
-    </>
+    <div className="flex items-center md:mr-4 mr-1">
+      <HeaderMenu />
+      <ProfileDropdown
+        image={session.user.image} 
+        name={session.user.name} 
+      />
+    </div>
   ) : (
     <div className="w-24 sm:w-32">
       <LoginButton/>

--- a/app/components/page/DairyRecord/CurrentDate.tsx
+++ b/app/components/page/DairyRecord/CurrentDate.tsx
@@ -11,7 +11,7 @@ export default function CurrentDate() {
     <div className="flex flex-row justify-center items-center w-full">
       <div className="flex flex-row items-center border-b-4 border-gray-100 p-1">
         <CalendarIcon className="w-6 h-6 text-gray-500 mr-2 ml-4"/>
-        <div className='text-lg mr-4'>{ formattedSelectedDate }</div>
+        <div className='text-lg mr-4 text-gray-600'>{ formattedSelectedDate }</div>
       </div>
     </div>
   )

--- a/app/components/page/DairyRecord/CustomersHoverCard.tsx
+++ b/app/components/page/DairyRecord/CustomersHoverCard.tsx
@@ -7,7 +7,7 @@ export default function CustomersHoverCard() {
     <Group justify="center">
       <HoverCard width={280} shadow="md">
         <HoverCard.Target>
-          <ActionIcon variant="light" size="lg" color="#60a5fa" radius="xl" aria-label="Settings" className="shadow-md hover:mt-1">
+          <ActionIcon variant="light" size="lg" color="#60a5fa" radius="xl" aria-label="Settings" className="shadow-md hover:-translate-y-1 hover:text-sky-700 transition-transform">
             <UsersIcon className="w-10 h-10 m-1 p-1"/>
           </ActionIcon>
         </HoverCard.Target>

--- a/app/components/page/DashBoard/CreateTarget.tsx
+++ b/app/components/page/DashBoard/CreateTarget.tsx
@@ -1,0 +1,21 @@
+'use client'
+import { useDisclosure } from '@mantine/hooks';
+import { Modal, Button } from '@mantine/core';
+import TargetInput from './TargetInput';
+import { CursorArrowRaysIcon } from "@heroicons/react/24/solid";
+
+export default function CreateTarget() {
+  const [opened, { open, close }] = useDisclosure(false);
+
+  return (
+    <>
+      <Button size="xs" variant="outline" color="#64748b" onClick={open}>
+        登録する
+        <CursorArrowRaysIcon className="w-5 h-5 ml-1 text-blue-400" />
+      </Button>
+      <Modal opened={opened} onClose={close} centered size="xs">
+        <TargetInput close={close} />
+      </Modal>
+    </>
+  )
+}

--- a/app/components/page/DashBoard/TargetInput.tsx
+++ b/app/components/page/DashBoard/TargetInput.tsx
@@ -1,0 +1,62 @@
+import axios from 'axios'
+import { useSession } from 'next-auth/react';
+import { getThisWeekRange, formatDateMD } from "@/utils/dateUtils";
+import { showSuccessNotification, showErrorNotification } from "@/utils/notifications";
+import useWeeklyStore from '@/store/weeklyStore';
+import useDashboardStore from "@/store/dashboardStore";
+import { CalendarIcon } from "@heroicons/react/24/outline";
+import SubmitButton from "../../ui/button/SubmitButton"
+import TargetInputForm from "../WeeklyTarget/TargetInputForm"
+
+type TargetInputProps = {
+  close: () => void;
+};
+
+export default function TargetInput({close} :TargetInputProps) {
+  const { data: session } = useSession();
+  const railsUserId = session?.user?.railsId;
+  const { target, clearData } = useWeeklyStore();
+  const { fetchWeeklyTarget } = useDashboardStore((state) => ({fetchWeeklyTarget: state.fetchWeeklyTarget}));
+  const { start, end } = getThisWeekRange();
+
+  const handleSubmit = async () => {
+
+    if (target !== 0) {
+      try {
+        await axios.post(`/api/weeklytarget`, {
+          weekly_target: {
+            target: target * 10000,
+            start_date: start,
+            end_date: end,
+          },
+        });
+        showSuccessNotification(`登録しました`);
+        if (railsUserId !== undefined) {
+          fetchWeeklyTarget(railsUserId, true);
+        }
+        close();
+        clearData();
+      } catch (error) {
+        showErrorNotification('目標の登録に失敗しました');
+        console.error("Failed to send weekly target", error);
+      }
+    }
+  };
+
+  return (
+    <div className="px-2">
+      <div className='flex flex-row justify-center items-start w-full text-lg pb-2 font-bold text-gray-700 border-b-2'>
+        <div className='flex w-full justify-center items-center'>
+          <CalendarIcon className="w-8 h-8 text-sky-800 mr-2" />
+          {formatDateMD(start)} 〜 {formatDateMD(end)}の目標
+        </div>
+      </div>
+      <div className="flex p-2 mx-5 justify-center">
+        <TargetInputForm />
+      </div>
+      <div className="flex p-2 mr-5 justify-end mt-2">
+        <SubmitButton size="sm" type="submit" onClick={handleSubmit} />
+      </div>
+    </div>
+  )
+}

--- a/app/components/page/DashBoard/WeeklyProgress.tsx
+++ b/app/components/page/DashBoard/WeeklyProgress.tsx
@@ -1,6 +1,6 @@
 import { formatCurrency } from "@/utils/currencyUtils";
-import RouterButton from "../../ui/button/RouterButton";
 import { ArrowTrendingUpIcon, FlagIcon } from "@heroicons/react/24/solid";
+import CreateTarget from "./CreateTarget";
 
 type WeeklyProgressProps = {
     target: number | null;
@@ -20,7 +20,7 @@ export default function WeeklyProgress({ target, amount }:WeeklyProgressProps ) 
           <div className="py-1 ml-1 text-lg font-bold">￥{target}万</div>
         ) : (
           <div className="pt-2 pb-1 ml-1">
-            <RouterButton size="xs" path="/weekly">登録する</RouterButton>
+            <CreateTarget />
           </div>
         )}
         <div className="flex items-center text-gray-700 border-t-2 mt-2 pt-2">

--- a/app/components/page/StepForm/Achievements.tsx
+++ b/app/components/page/StepForm/Achievements.tsx
@@ -45,7 +45,7 @@ export default function Achievements() {
                 size="lg"
                 color="#60a5fa"
                 aria-label="Settings" 
-                className="shadow-md hover:mt-1 hover:text-sky-700"
+                className="shadow-md hover:-translate-y-1 hover:text-sky-700 transition-transform"
                 onClick={open}
               >
                 <CursorArrowRaysIcon className="w-8 h-8 p-1"/>


### PR DESCRIPTION
## 概要

今週の目標未登録時、ダッシュボードから登録できる
issue: #35 

その他：
ベースレイアウトの調整とアクションアイコンの修正

## 変更点

- ボタンにモーダルを追加、モーダル内に目標入力フォームと送信ボタンを設置

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0
- ダッシュボードから今週の目標の登録ができる

## 影響範囲
- /dashboard
- weekly

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応