### PR TITLE
Jobs_2 #60

### DIFF
--- a/app/api/jobrecord/route.ts
+++ b/app/api/jobrecord/route.ts
@@ -41,3 +41,52 @@ export async function GET()  {
     });
   }
 }
+
+export async function POST(request: Request) {
+
+  const session = await getServerSession(options);
+    
+  if (!session) {
+    return new Response(JSON.stringify({ error: '認証が必要です' }), {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  const data = await request.json();
+  const job_record = data.job_record;
+
+  if (!job_record){
+    return new Response(JSON.stringify({ error: 'job_recordがありません' }), {
+        status: 400,
+        headers: {
+            "Content-Type": "application/json"
+        }
+    });
+  }
+
+  job_record.user_id = session.user.railsId;
+  const apiUrl = process.env.RAILS_API_URL
+
+  try {
+    const response = await axios.post(`${apiUrl}/job_records`, { 
+      job_record
+    });
+      return new Response(JSON.stringify(response.data), {
+        status: 200,
+        headers: {
+            "Content-Type": "application/json",
+        },
+    });
+  } catch (error) {
+    console.error(error); 
+    return new Response(JSON.stringify({ error: '予期せぬエラーが発生しました'  }), {
+        status: 500,
+        headers: {
+          "Content-Type": "application/json",
+        },
+    });
+  }
+}

--- a/app/components/page/DairyRecord/CustomersHoverCard.tsx
+++ b/app/components/page/DairyRecord/CustomersHoverCard.tsx
@@ -7,7 +7,7 @@ export default function CustomersHoverCard() {
     <Group justify="center">
       <HoverCard width={280} shadow="md">
         <HoverCard.Target>
-          <ActionIcon variant="light" size="lg" color="#60a5fa" radius="xl" aria-label="Settings" className="shadow-md hover:-translate-y-1 hover:text-sky-700 transition-transform">
+          <ActionIcon variant="light" size="lg" color="#60a5fa" radius="xl" aria-label="Settings" className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform">
             <UsersIcon className="w-10 h-10 m-1 p-1"/>
           </ActionIcon>
         </HoverCard.Target>

--- a/app/components/page/DashBoard/JobRecord.tsx
+++ b/app/components/page/DashBoard/JobRecord.tsx
@@ -11,7 +11,7 @@ export default function JobRecord({ records }: JobRecordProps) {
     <>
       <div className="p-4 border-t-4">
         {records.map((record, index) => (
-          <div key={index} className="flex flex-row py-1 text-gray-700">
+          <div key={index} className="flex flex-row py-1 text-md text-gray-700">
             <CheckBadgeIcon className="w-6 h-6 text-sky-800 mr-2" />
             <div>{record.job}</div>
           </div>

--- a/app/components/page/DashBoard/JobsCalendar.tsx
+++ b/app/components/page/DashBoard/JobsCalendar.tsx
@@ -8,7 +8,7 @@ import { DatePicker } from '@mantine/dates';
 import CalendarIndicator from '../../ui/CalendarIndicator';
 import CalendarModal from './CalendarModal';
 import JobRecord from './JobRecord';
-import JobsInput from './JobsInput';
+import NotJobRecord from './NotJobRecord';
 
 export default function JobsCalender() {
   useFetchJobs();
@@ -45,7 +45,7 @@ export default function JobsCalender() {
   const renderModalContent = () => {
     return selectedJobsRecords.length > 0 
       ? <JobRecord records={selectedJobsRecords} /> 
-      : <JobsInput />;
+      : <NotJobRecord selectedDate={selectedDate} close={close} />;
   };
   
   return (

--- a/app/components/page/DashBoard/JobsInput.tsx
+++ b/app/components/page/DashBoard/JobsInput.tsx
@@ -1,9 +1,60 @@
-export default function JobsInput() {
+"use client"
+import { useState } from 'react';
+import { z } from 'zod';
+import { showErrorNotification } from '@/utils/notifications';
+import { Autocomplete, ActionIcon } from "@mantine/core";
+import { PlusIcon, TrashIcon } from '@heroicons/react/24/outline';
+
+type JobsInputProps = {
+  data: string[];
+  jobs: string[];
+  setJobs: React.Dispatch<React.SetStateAction<string[]>>;
+}
+
+export default function JobsInput({data, jobs, setJobs}: JobsInputProps) {
+  const [ value, setValue] = useState('');
+  
+  const uniqueData = Array.from(new Set(data));
+  const filteredData = uniqueData.filter(job => !jobs.includes(job));
+
+  const schema = z.string().min(1, "業務を入力してください").max(20, "20文字以内で入力してください")
+  .refine(content => content.trim().length > 0, "空白は無効です");
+  
+  const addData = () => {
+    const validationResult = schema.safeParse(value);
+    if (validationResult.success) {
+      if (!jobs.includes(value)) {
+        setJobs(prevJobs => [...prevJobs, value]);
+        setValue('');
+      }
+    } else {
+      const errorMessage = validationResult.error.issues[0].message;
+      showErrorNotification(errorMessage, '入力内容を確認してください');
+    }
+  };
+
+  const clearData = () => {
+    setJobs([]);
+  };
+
   return (
     <>
-      <div className="p-4 border-t-4">
-        <div className="mb-2 flex">
-          <div className='text-sm'>業務を登録</div>
+      <Autocomplete
+        placeholder="店内レイアウト など"
+        data={filteredData}
+        value={value}
+        onChange={setValue}
+      />
+      <div className='flex flex-row ml-2'>
+        <div>
+          <ActionIcon color="#93c5fd" size="lg" onClick={addData} className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform">
+            <PlusIcon className='w-12 h-12 p-1' />
+          </ActionIcon>
+        </div>
+        <div className='ml-2'>
+          <ActionIcon color="#cbd5e1" size="lg" onClick={clearData} className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform">
+            <TrashIcon className='w-12 h-12 p-1' />
+          </ActionIcon>
         </div>
       </div>
     </>

--- a/app/components/page/DashBoard/NotJobRecord.tsx
+++ b/app/components/page/DashBoard/NotJobRecord.tsx
@@ -1,0 +1,76 @@
+"use client"
+import { useState } from 'react';
+import { useSession } from 'next-auth/react';
+import axios from 'axios'
+import useDashboardStore from '@/store/dashboardStore';
+import { formatDate } from '@/utils/dateUtils';
+import { showErrorNotification, showSuccessNotification } from '@/utils/notifications';
+import JobsInput from "./JobsInput";
+import SubmitButton from '../../ui/button/SubmitButton';
+import { PencilIcon } from "@heroicons/react/24/outline";
+import { CheckCircleIcon } from "@heroicons/react/24/solid";
+
+type  NotJobRecordProps = {
+  selectedDate: Date | null;
+  close: () => void;
+}
+
+export default function NotJobRecord({ selectedDate, close } :NotJobRecordProps) {
+  const [ jobs, setJobs ] = useState<string[]>([]);
+  const { jobsList } = useDashboardStore();
+  const { data: session } = useSession();
+  const railsUserId = session?.user?.railsId;
+  const { fetchJobsRecord } = useDashboardStore((state) => ({fetchJobsRecord: state.fetchJobsRecord}));
+
+  const handleSubmit = async () => {
+    if (selectedDate !== null && jobs.length !== 0 ) {
+      try {
+        await axios.post(`/api/jobrecord`, {
+          job_record: {
+            date: formatDate(selectedDate),
+            jobs,
+          },
+        });
+        showSuccessNotification(`登録しました`);
+        if (railsUserId !== undefined) {
+          fetchJobsRecord(railsUserId, true);
+        }
+        close();
+        setJobs([]);
+      } catch (error) {
+        showErrorNotification('登録に失敗しました');
+        console.error("Failed to send weekly target", error);
+      }
+    }
+  };
+
+  return (
+    <>
+      <div className="p-4 border-t-4">
+        <div className='flex flex-col  w-full items-start'>
+          <div className='flex w-full text-gray-700 font-bold items-center'>
+            <PencilIcon className="w-5 h-5 text-sky-800 mr-2" />
+            <div>業務を記録する</div>
+          </div>
+          <div className='text-xs text-gray-500'>20文字以内 / 最大3つまで登録できます</div>
+          <div className="flex py-3">
+            <JobsInput data={jobsList} jobs={jobs} setJobs={setJobs}/>
+          </div>
+          <div className='flex flex-col px-2 mx-5'>
+            {jobs.map((job, index) => 
+              <div key={index} className='flex flex-row'>
+                <CheckCircleIcon className="w-4 h-4 text-blue-400 mr-1" />
+                <span className="text-sm font-medium">{job}</span>
+              </div>
+            )} 
+          </div>
+        </div>
+        {jobs.length > 0 && 
+          <div className="flex justify-end mr-3">
+            <SubmitButton size="sm" onClick={handleSubmit}/>
+          </div>
+        }
+      </div>
+    </>
+  )
+}

--- a/app/components/page/StepForm/Achievements.tsx
+++ b/app/components/page/StepForm/Achievements.tsx
@@ -45,7 +45,7 @@ export default function Achievements() {
                 size="lg"
                 color="#60a5fa"
                 aria-label="Settings" 
-                className="shadow-md hover:-translate-y-1 hover:text-sky-700 transition-transform"
+                className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform"
                 onClick={open}
               >
                 <CursorArrowRaysIcon className="w-8 h-8 p-1"/>

--- a/app/components/page/StepForm/StepForm.tsx
+++ b/app/components/page/StepForm/StepForm.tsx
@@ -26,21 +26,43 @@ export default function StepForm() {
 
   const [active, setActive] = useState(0);
 
+  function validateContentStep() {
+    const validationResult = validateContent();
+    if (!validationResult.success) {
+      return { success: false, errorMessage: validationResult.error?.issues[0].message };
+    }
+    return { success: true, errorMessage: '' };
+  }
+
+  function validateTargetStep() {
+  const validationResult = validateTarget();
+  if (!validationResult.success) {
+    return { success: false, errorMessage: validationResult.error?.issues[0].message };
+  }
+  return { success: true, errorMessage: '' };
+}
+
   function validateStep(step :number) {
+    let validationResult;
+    let errorMessage = '';
+
     switch (step) {
       case 0:
-        return {
-          success: validateContent().success,
-          errorMessage: '1〜300文字で週間レポートを入力してください'
-        };
+        validationResult = validateContent();
+        if (!validationResult.success) {
+          errorMessage = validationResult.error?.issues[0].message || '正しく入力してください';
+        }
+        break;
       case 1:
-        return {
-          success: validateTarget().success,
-          errorMessage: '目標金額に0は設定できません'
-        };
+        validationResult = validateTarget();
+        if (!validationResult.success) {
+          errorMessage = validationResult.error?.issues[0].message || '正しく入力してください';
+        }
+        break;
       default:
-        return { success: true, errorMessage: '' };
+        errorMessage = '';
     }
+    return { success: validationResult ? validationResult.success : false, errorMessage };
   }
 
   const nextStep = () => {

--- a/app/components/ui/button/SubmitButton.tsx
+++ b/app/components/ui/button/SubmitButton.tsx
@@ -9,7 +9,7 @@ type SubmitButtonProps = {
 
 export default function SubmitButton({ size, type, onClick }: SubmitButtonProps) {
   return (
-    <Button type={type} size={size} variant="outline" color="#9ca3af" onClick={onClick}>
+    <Button type={type} size={size} variant="outline" color="#9ca3af" onClick={onClick} className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform" >
       登録
       <PaperAirplaneIcon className="w-5 h-5 ml-1 text-blue-400" />
     </Button>

--- a/store/dashboardStore.ts
+++ b/store/dashboardStore.ts
@@ -19,6 +19,7 @@ type DashboardState = {
   thisWeekAverage: number;
   jobsRecords: JobRecord[];
   jobsDates: string[];
+  jobsList: string[];
   fetchSalesRecord: (userId: number, force?: boolean) => Promise<void>;
   fetchWeeklyReport: (userId: number, force?: boolean) => Promise<void>;
   fetchWeeklyTarget: (userId: number, force?: boolean) => Promise<void>;
@@ -42,7 +43,8 @@ const useDashboardStore = create<DashboardState>((set, get) => ({
   thisWeekSet: 0,
   thisWeekAverage: 0,
   jobsRecords: [],
-  jobsDates: [], // 売上記録の日付データ
+  jobsDates: [], 
+  jobsList: [],
   fetchSalesRecord: async (userId, force = false) => {
     if (force || get().lastFetchedUserId !== userId || get().salesRecords.length === 0) {
       try {
@@ -130,10 +132,12 @@ const useDashboardStore = create<DashboardState>((set, get) => ({
         const response = await fetch(`/api/jobrecord`);
         const data: JobRecord[] = await response.json();
         const dates = data.map(record => record.date);
+        const jobs = data.map(record => record.job);
         set({
           jobsRecords: data, 
           jobsDates: dates, 
           lastFetchedUserId: userId,
+          jobsList: jobs,
         });
       } catch (error) {
         console.error("Failed to fetch", error);

--- a/store/weeklyStore.ts
+++ b/store/weeklyStore.ts
@@ -5,10 +5,10 @@ import { getTargetDateRange } from '@/utils/dateUtils';
 import { formatDate } from '@/utils/dateUtils';
 
 const targetSchema = z.object({
-  target: z.number().min(1).max(200),
+  target: z.number().min(1, "目標は0で登録できません").max(200),
 });
 const contentSchema = z.object({
-  content: z.string().min(1).max(300) .refine(content => content.trim().length > 0),
+  content: z.string().min(1, "レポートを入力してください").max(300, "300文字以内で入力してください").refine(content => content.trim().length > 0, "空白は無効です"),
 });
 
 const initialReportDateRange = getReportDateRange();


### PR DESCRIPTION
## 概要

業務未登録の日付のモーダルに、業務登録フォームを設置。
issue: #60 

その他：
ステップ入力ページのバリデーションエラーメッセージをアップデート

## 変更点

- 登録用APIルート, 送信関数の実装, フォームの作成
- オートコンプリート
そのユーザーが過去登録したアイテムが選択肢として表示される。それ以外も入力可
- バリデーション
スキーマでの制限, 日付とJobの組み合わせの一意制約, 1日に３つまでの登録制限

- ステップ入力時のエラーメッセージをzodのエラーメッセージに修正
 

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0

- モーダルを開き業務の登録ができる。入力候補が表示される
- バリデーションが機能し、エラーメッセージが表示される

## 影響範囲
- /dashboard
- weekly

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応
