### PR TITLE
MonthlyArchive #45

### DIFF
--- a/app/(authenticated)/archive/page.tsx
+++ b/app/(authenticated)/archive/page.tsx
@@ -1,0 +1,10 @@
+import MonthlyArchive from "@/app/components/page/Archive/MonthlyArchive"
+
+export default function Archive() {
+
+  return (
+    <>
+    <MonthlyArchive />
+    </>
+  )
+}

--- a/app/components/page/Archive/MonthlyArchive.tsx
+++ b/app/components/page/Archive/MonthlyArchive.tsx
@@ -1,0 +1,37 @@
+"use client"
+import { useState } from "react";
+import { formatDateYM } from "@/utils/dateUtils";
+import { calculateTotal, calculateSetRate, calculateAverage } from "@/utils/calculateUtils";
+import useDashboardStore from "@/store/dashboardStore";
+import MonthlyRecord from "./MonthlyRecord";
+import WeeklyRecord from "./WeeklyRecord";
+import MonthPicker from "../../ui/MonthPicker";
+
+export default function MonthlyArchive() {
+  const { salesRecords } = useDashboardStore();
+  const [value, setValue] = useState<Date | null>(new Date());
+
+  const targetMonth = formatDateYM(value);
+
+  const filteredSalesRecords = salesRecords.filter(record => {
+    const recordMonth = record.date.substring(0, 7); 
+    return recordMonth === targetMonth;
+  });
+  
+  const monthlyAmount = calculateTotal(filteredSalesRecords, 'total_amount');
+  const monthlyNumber = calculateTotal(filteredSalesRecords, 'total_number');
+  const monthlyCount = calculateTotal(filteredSalesRecords, 'count');
+  const monthlySetRate = calculateSetRate(monthlyNumber, monthlyCount);
+  const monthlyAverage = calculateAverage(monthlyAmount, monthlyCount);
+
+  return (
+    <>
+    <MonthPicker value={value} setValue={setValue} />
+
+    <MonthlyRecord amount={monthlyAmount} number={monthlyNumber} count={monthlyCount} setRate={monthlySetRate} average={monthlyAverage}/>
+
+    <WeeklyRecord monthRecords={filteredSalesRecords} />
+
+    </>
+  )
+}

--- a/app/components/page/Archive/MonthlyRecord.tsx
+++ b/app/components/page/Archive/MonthlyRecord.tsx
@@ -1,0 +1,21 @@
+import { formatCurrency } from "@/utils/currencyUtils";
+
+type MonthlyRecordProps = {
+  amount: number;
+  number: number; 
+  count: number;
+  setRate: number;
+  average: number;
+};
+
+export default function MonthlyRecord({amount, number, count, setRate, average} :MonthlyRecordProps) {
+  return (
+    <>
+      <div>トータル金額: {formatCurrency(amount)}</div>
+      <div>トータル点数: {number}</div>
+      <div>トータル客数: {count}</div>
+      <div>セット率: {setRate.toFixed(1)}</div>
+      <div>客単価: {formatCurrency(average)}</div>
+    </>
+  )
+}

--- a/app/components/page/Archive/WeeklyRecord.tsx
+++ b/app/components/page/Archive/WeeklyRecord.tsx
@@ -1,0 +1,50 @@
+import { SalesRecord } from "@/types";
+import { getWeekHead, sortData } from "@/utils/dateUtils";
+import { calculateSetRate, calculateAverage } from "@/utils/calculateUtils";
+import { formatCurrency } from "@/utils/currencyUtils";
+
+type WeeklyRecordProps = {
+  monthRecords: SalesRecord[];
+};
+
+type WeeklyData = {
+  amount: number;
+  number: number;
+  count: number;
+  setRate: number;
+  average: number;
+};
+
+export default function WeeklyRecord({monthRecords} :WeeklyRecordProps) {
+
+  const weeklyData = monthRecords.reduce<Record<string, WeeklyData>>((acc, record) => {
+    const weekHead = getWeekHead(record.date);
+    if (!acc[weekHead]) {
+        acc[weekHead] = { amount: 0, number: 0, count: 0, setRate: 0, average: 0 };
+      }
+        acc[weekHead].amount += record.total_amount;
+        acc[weekHead].number += record.total_number;
+        acc[weekHead].count += record.count;
+        
+        acc[weekHead].setRate = calculateSetRate(acc[weekHead].number, acc[weekHead].count)
+        acc[weekHead].average = calculateAverage(acc[weekHead].amount, acc[weekHead].count)
+        return acc;
+  }, {});
+
+  const sortedWeeklyData = sortData(weeklyData);
+
+  return (
+    <>
+    {sortedWeeklyData.map(weekKey => (
+      <div key={weekKey}>
+        <div>{weekKey} 〜</div>
+        <div>金額: {formatCurrency(weeklyData[weekKey].amount)}</div>
+        <div>点数: {weeklyData[weekKey].number}</div>
+        <div>客数: {weeklyData[weekKey].count}</div>
+        <div>セット率: {weeklyData[weekKey].setRate.toFixed(1)}</div>
+        <div>客単価: {formatCurrency(weeklyData[weekKey].average)}</div>
+      </div>
+    ))}
+    </>
+  )
+}

--- a/app/components/page/DairyRecord/Submit.tsx
+++ b/app/components/page/DairyRecord/Submit.tsx
@@ -37,12 +37,12 @@ export default function Submit() {
 
       // response.dataから日付を取得
       const date = response.data.dairy_record.date;
-      showSuccessNotification(`${date}の売上を登録しました`);
-      clearData();
       if (railsUserId !== undefined) {
         fetchSalesRecord(railsUserId, true);
       }
       router.push('/dashboard');
+      showSuccessNotification(`${date}の売上を登録しました`);
+      clearData();
     } catch (error) {
       showErrorNotification('送信に失敗しました。もう一度お試しください。');
       console.error("Failed to fetch", error);

--- a/app/components/page/DashBoard/ContentsLink.tsx
+++ b/app/components/page/DashBoard/ContentsLink.tsx
@@ -1,0 +1,29 @@
+"use client"
+import { useRouter } from 'next/navigation'
+import { ChartBarIcon, ChartPieIcon, BookOpenIcon } from "@heroicons/react/24/outline";
+
+export default function ContentsLink() {
+  const router = useRouter()
+  return (
+    <div className="flex flex-row justify-center items-center h-20 md:h-28 md:pb-3 md:mx-2 lg:mx-10">
+      <div className="w-1/3 mx-2">
+        <div className='flex flex-col justify-center items-center text-gray-400 hover:text-sky-700 p-5 md:p-6 bg-white shadow-md rounded-md hover:shadow-lg hover:shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform cursor-pointer'>
+          <ChartPieIcon className="w-8 h-8"/>
+          <div className='text-xs text-gray-600 mt-1'>客層</div>
+        </div>
+      </div>
+      <div className="w-1/3 mx-2">
+        <div className='flex flex-col justify-center items-center text-gray-400 hover:text-sky-700 p-5 md:p-6 bg-white shadow-md rounded-md hover:shadow-lg hover:shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform cursor-pointer' onClick={() => router.push('/archive')}>
+          <ChartBarIcon className="w-8 h-8" />
+          <div className='text-xs text-gray-600 mt-1'>月間実績</div>
+        </div>
+      </div>
+      <div className="w-1/3 mx-2">
+        <div className='flex flex-col justify-center items-center text-gray-400 hover:text-sky-700 p-5 md:p-6 bg-white shadow-md rounded-md hover:shadow-lg hover:shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform cursor-pointer'>
+          <BookOpenIcon className="w-8 h-8" />
+          <div className='text-xs text-gray-600 mt-1'>レポート</div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/components/page/DashBoard/JobsInput.tsx
+++ b/app/components/page/DashBoard/JobsInput.tsx
@@ -47,12 +47,12 @@ export default function JobsInput({data, jobs, setJobs}: JobsInputProps) {
       />
       <div className='flex flex-row ml-2'>
         <div>
-          <ActionIcon color="#93c5fd" size="lg" onClick={addData} className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform">
+          <ActionIcon variant="filled" color="#93c5fd" size="lg" onClick={addData} className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform">
             <PlusIcon className='w-12 h-12 p-1' />
           </ActionIcon>
         </div>
         <div className='ml-2'>
-          <ActionIcon color="#cbd5e1" size="lg" onClick={clearData} className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform">
+          <ActionIcon variant="filled" color="#cbd5e1" size="lg" onClick={clearData} className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform">
             <TrashIcon className='w-12 h-12 p-1' />
           </ActionIcon>
         </div>

--- a/app/components/page/DashBoard/ProgressArea.tsx
+++ b/app/components/page/DashBoard/ProgressArea.tsx
@@ -1,33 +1,12 @@
+import ContentsLink from './ContentsLink'
 import ThisWeek from './ThisWeek'
-import { ChartBarIcon, ChartPieIcon, BookOpenIcon } from "@heroicons/react/24/outline";
 
 export default function ProgressArea() {
   return (
     <>
       <div className="flex flex-col w-full max-w-lg mb-5 pb-2">
         <ThisWeek/>
-
-        <div className="flex flex-row justify-center items-center h-20 md:h-28 md:pb-3 md:mx-2 lg:mx-10">
-          <div className="w-1/3 mx-2">
-            <div className='flex flex-col justify-center items-center text-gray-400 hover:text-sky-700 p-5 md:p-6 bg-white shadow-md rounded-md hover:mt-1'>
-              <ChartPieIcon className="w-8 h-8"/>
-              <div className='text-xs text-gray-600 mt-1'>客層</div>
-            </div>
-          </div>
-          <div className="w-1/3 mx-2">
-          <div className='flex flex-col justify-center items-center text-gray-400 hover:text-sky-700 p-5 md:p-6 bg-white shadow-md rounded-md hover:mt-1'>
-              <ChartBarIcon className="w-8 h-8" />
-              <div className='text-xs text-gray-600 mt-1'>月間実績</div>
-            </div>
-          </div>
-          <div className="w-1/3 mx-2">
-          <div className='flex flex-col justify-center items-center text-gray-400 hover:text-sky-700 p-5 md:p-6 bg-white shadow-md rounded-md hover:mt-1'>
-              <BookOpenIcon className="w-8 h-8" />
-              <div className='text-xs text-gray-600 mt-1'>レポート</div>
-            </div>
-          </div>
-        </div>
-
+        <ContentsLink/>
       </div>
     </>
   )

--- a/app/components/ui/MonthPicker.tsx
+++ b/app/components/ui/MonthPicker.tsx
@@ -1,0 +1,23 @@
+import { CalendarIcon } from "@heroicons/react/24/outline";
+import { rem } from "@mantine/core";
+import { MonthPickerInput } from '@mantine/dates';
+
+type MonthPickerProps = {
+    value: Date | null;
+    setValue: (newValue: Date | null) => void;
+}
+
+export default function MonthPicker({value, setValue} :MonthPickerProps ) {
+  const icon = <CalendarIcon style={{ width: rem(18), height: rem(18) }}/>;
+
+  return (
+    <MonthPickerInput
+      leftSection={icon}
+      leftSectionPointerEvents="none"
+      label="Pick date"
+      placeholder="Pick date"
+      value={value}
+      onChange={setValue}
+    />
+  )
+}

--- a/store/dashboardStore.ts
+++ b/store/dashboardStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { SalesRecord, WeeklyTarget, WeeklyReport, ProgressData, ResisteredDateRange, JobRecord } from '@/types';
 import { getThisWeekRange } from '@/utils/dateUtils';
+import { calculateTotal, calculateSetRate, calculateAverage } from '@/utils/calculateUtils';
 
 type DashboardState = {
   lastFetchedUserId: number | null;
@@ -55,11 +56,11 @@ const useDashboardStore = create<DashboardState>((set, get) => ({
         const thisWeekRecord = data.filter(record => 
           record.date >= start && record.date <= end
         );
-        const thisWeekAmount = thisWeekRecord.reduce((sum, record) => sum + record.total_amount, 0);
-        const thisWeekNumber = thisWeekRecord.reduce((sum, record) => sum + record.total_number, 0);
-        const thisWeekCount = thisWeekRecord.reduce((sum, record) => sum + record.count, 0);
-        const thisWeekSet = thisWeekCount > 0 ? thisWeekNumber / thisWeekCount : 0;
-        const thisWeekAverage = thisWeekCount > 0 ? thisWeekAmount / thisWeekCount : 0;
+        const thisWeekAmount = calculateTotal(thisWeekRecord, 'total_amount');
+        const thisWeekNumber = calculateTotal(thisWeekRecord, 'total_number');
+        const thisWeekCount = calculateTotal(thisWeekRecord, 'count');
+        const thisWeekSet = calculateSetRate(thisWeekNumber, thisWeekCount);
+        const thisWeekAverage = calculateAverage(thisWeekAmount, thisWeekCount);
         set({
           salesRecords: data, 
           salesDates: dates, 

--- a/utils/calculateUtils.ts
+++ b/utils/calculateUtils.ts
@@ -1,0 +1,13 @@
+export const calculateTotal = <T extends Record<string, any>>(records: T[], property: keyof T): number => {
+  return records.reduce((sum, record) => {
+    return sum + (record[property] as number);
+  }, 0);
+};
+
+export const calculateSetRate = (totalNumber: number, totalCount: number): number => {
+  return totalCount > 0 ? totalNumber / totalCount : 0;
+};
+
+export const calculateAverage = (totalAmount: number, totalCount: number): number => {
+  return totalCount > 0 ? totalAmount / totalCount : 0;
+};

--- a/utils/dateUtils.ts
+++ b/utils/dateUtils.ts
@@ -3,16 +3,17 @@ import dayjs from 'dayjs';
 import isoWeek from 'dayjs/plugin/isoWeek';
 dayjs.extend(isoWeek);
 
+// Date型で受け取る
 export const formatDate = (date :Date) => {
   return dayjs(date).format('YYYY-MM-DD');
 };
 
-export const formatDateLayout = (date :Date) => {
-  return dayjs(date).format("YYYY / MM / DD   ( ddd )");
+export const formatDateYM = (date :Date | null ) => {
+  return dayjs(date).format('YYYY-MM');
 };
 
-export const formatDateMD = (date :string) => {
-  return dayjs(date).format("MM/DD");
+export const formatDateLayout = (date :Date) => {
+  return dayjs(date).format("YYYY / MM / DD   ( ddd )");
 };
 
 export const getStartOfWeek = (date :Date) => {
@@ -45,8 +46,6 @@ export const isDateInRanges = (date: Date, ranges: ResisteredDateRange[]): boole
   return ranges.some(range => {
     const startDate = dayjs(range.startDate);
     const endDate = dayjs(range.endDate);
-
-    // checkDate が startDate と endDate の間にあるかチェック
     return checkDate.isAfter(startDate.subtract(1, 'day')) && checkDate.isBefore(endDate.add(1, 'day'));
   });
 };
@@ -57,3 +56,16 @@ export const getThisWeekRange = () => {
   const end = formatDate(getEndOfWeek(new Date()));
   return { start, end };
 };
+
+// string型で受け取る
+export const getWeekHead = (date :string) => {
+  return dayjs(date).startOf('isoWeek').format('MM / DD');
+}
+
+export const formatDateMD = (date :string) => {
+  return dayjs(date).format("MM/DD");
+};
+
+export const sortData = (data: Record<string, any>) => {
+  return Object.keys(data).sort((a, b) => dayjs(a).diff(dayjs(b)))
+}


### PR DESCRIPTION
## 概要

選択した月の月間売り上げ実績を表示する。
またその月の週毎の実績を表示する。

issue: #45 

## 変更点

- archiveページの作成
- 再利用するMonthPickerの作成
- ストアの売上レコードの一覧から月間、週毎のレコードを抽出し
各プロパティ（売上合計、セット率etc）を算出し表示できる状態まで。

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0

- dashboardから月間実績ページに遷移できる
- 遷移先で実績が表示される
  - 遷移後今月の実績が表示されている
  - 今月の週毎の実績が昇順で表示されている
  - MonthPicker操作毎に選択された月の値が表示される
 
上記の動作を確認

## 影響範囲
- /dashboard
- /archive

## コメント
UI未実装