### PR TITLE
MonthlyArchive_2 #46

### DIFF
--- a/app/(authenticated)/archive/page.tsx
+++ b/app/(authenticated)/archive/page.tsx
@@ -3,8 +3,8 @@ import MonthlyArchive from "@/app/components/page/Archive/MonthlyArchive"
 export default function Archive() {
 
   return (
-    <>
-    <MonthlyArchive />
-    </>
+    <div className="flex flex-col justify-center items-center mx-auto px-6 z-0 max-w-4xl my-10 xl:my-20">
+      <MonthlyArchive />
+    </div>
   )
 }

--- a/app/(authenticated)/archive/page.tsx
+++ b/app/(authenticated)/archive/page.tsx
@@ -1,10 +1,14 @@
 import MonthlyArchive from "@/app/components/page/Archive/MonthlyArchive"
+import Breadcrumbs from "@/app/components/ui/Breadcrumbs"
 
 export default function Archive() {
 
   return (
-    <div className="flex flex-col justify-center items-center mx-auto px-6 z-0 max-w-4xl my-10 xl:my-20">
-      <MonthlyArchive />
-    </div>
+    <>
+      <Breadcrumbs>archive</Breadcrumbs>
+      <div className="flex flex-col justify-center items-center mx-auto px-6 z-0 max-w-4xl mb-7 mt-4">
+        <MonthlyArchive />
+      </div>
+    </>
   )
 }

--- a/app/components/page/Archive/MonthlyArchive.tsx
+++ b/app/components/page/Archive/MonthlyArchive.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { useState } from "react";
+import { useFetchResisterdDay } from "@/lib/useFetchData";
 import { formatDateYM } from "@/utils/dateUtils";
 import { calculateTotal, calculateSetRate, calculateAverage } from "@/utils/calculateUtils";
 import useDashboardStore from "@/store/dashboardStore";
@@ -9,6 +10,9 @@ import MonthPicker from "../../ui/MonthPicker";
 import { TriangleIcon } from "../../ui/icon/Triangle";
 
 export default function MonthlyArchive() {
+
+  useFetchResisterdDay();
+
   const { salesRecords } = useDashboardStore();
   const [value, setValue] = useState<Date | null>(new Date());
 
@@ -29,23 +33,20 @@ export default function MonthlyArchive() {
     <>
     <div className="flex flex-col justify-center w-full max-w-lg py-7 bg-white rounded-sm">
 
-      <div className="flex flex-row justify-start pl-9">
-        <TriangleIcon className="w-4 h-4 mr-1 ml-2 text-blue-300" />
+      <div className="flex flex-row justify-start px-7 md:px-12">
+        <TriangleIcon className="w-4 h-4 mr-1 ml-4 text-blue-300" />
         <div className='text-xs text-gray-500'>月を選択</div>
       </div>
 
-      <div className="flex flex-col w-full justify-center items-center px-7"> 
-        <div className="w-full items-center max-w-md p-2 md:px-3">
+      <div className="flex flex-col w-full justify-center items-center px-7 md:px-12"> 
+        <div className="w-full items-center max-w-md p-3">
           <MonthPicker value={value} setValue={setValue} />
         </div>
       </div>
 
       <MonthlyRecord amount={monthlyAmount} number={monthlyNumber} count={monthlyCount} setRate={monthlySetRate} average={monthlyAverage}/>
-
-    </div>
-
-    {/* <WeeklyRecord monthRecords={filteredSalesRecords} /> */}
-
+      <WeeklyRecord monthRecords={filteredSalesRecords} />
+    </div>    
     </>
   )
 }

--- a/app/components/page/Archive/MonthlyArchive.tsx
+++ b/app/components/page/Archive/MonthlyArchive.tsx
@@ -5,7 +5,7 @@ import { formatDateYM } from "@/utils/dateUtils";
 import { calculateTotal, calculateSetRate, calculateAverage } from "@/utils/calculateUtils";
 import useDashboardStore from "@/store/dashboardStore";
 import MonthlyRecord from "./MonthlyRecord";
-import WeeklyRecord from "./WeeklyRecord";
+import WeeklyArchive from "./WeeklyArchive";
 import MonthPicker from "../../ui/MonthPicker";
 import { TriangleIcon } from "../../ui/icon/Triangle";
 
@@ -22,6 +22,8 @@ export default function MonthlyArchive() {
     const recordMonth = record.date.substring(0, 7); 
     return recordMonth === targetMonth;
   });
+
+  const numberOfDays = filteredSalesRecords.length;
   
   const monthlyAmount = calculateTotal(filteredSalesRecords, 'total_amount');
   const monthlyNumber = calculateTotal(filteredSalesRecords, 'total_number');
@@ -29,23 +31,24 @@ export default function MonthlyArchive() {
   const monthlySetRate = calculateSetRate(monthlyNumber, monthlyCount);
   const monthlyAverage = calculateAverage(monthlyAmount, monthlyCount);
 
+
   return (
     <>
-    <div className="flex flex-col justify-center w-full max-w-lg py-7 bg-white rounded-sm">
+    <div className="flex flex-col justify-center w-full max-w-lg py-7 bg-white rounded-md">
 
-      <div className="flex flex-row justify-start px-7 md:px-12">
+      <div className="flex flex-row justify-start px-7 pt-2 md:px-12">
         <TriangleIcon className="w-4 h-4 mr-1 ml-4 text-blue-300" />
-        <div className='text-xs text-gray-500'>月を選択</div>
+        <div className='text-sm text-gray-800'>月を選択</div>
       </div>
 
       <div className="flex flex-col w-full justify-center items-center px-7 md:px-12"> 
-        <div className="w-full items-center max-w-md p-3">
+        <div className="w-full items-center max-w-md px-3 py-2">
           <MonthPicker value={value} setValue={setValue} />
         </div>
       </div>
 
-      <MonthlyRecord amount={monthlyAmount} number={monthlyNumber} count={monthlyCount} setRate={monthlySetRate} average={monthlyAverage}/>
-      <WeeklyRecord monthRecords={filteredSalesRecords} />
+      <MonthlyRecord amount={monthlyAmount} number={monthlyNumber} count={monthlyCount} setRate={monthlySetRate} average={monthlyAverage} days={numberOfDays}/>
+      <WeeklyArchive monthRecords={filteredSalesRecords} />
     </div>    
     </>
   )

--- a/app/components/page/Archive/MonthlyArchive.tsx
+++ b/app/components/page/Archive/MonthlyArchive.tsx
@@ -6,6 +6,7 @@ import useDashboardStore from "@/store/dashboardStore";
 import MonthlyRecord from "./MonthlyRecord";
 import WeeklyRecord from "./WeeklyRecord";
 import MonthPicker from "../../ui/MonthPicker";
+import { TriangleIcon } from "../../ui/icon/Triangle";
 
 export default function MonthlyArchive() {
   const { salesRecords } = useDashboardStore();
@@ -26,11 +27,24 @@ export default function MonthlyArchive() {
 
   return (
     <>
-    <MonthPicker value={value} setValue={setValue} />
+    <div className="flex flex-col justify-center w-full max-w-lg py-7 bg-white rounded-sm">
 
-    <MonthlyRecord amount={monthlyAmount} number={monthlyNumber} count={monthlyCount} setRate={monthlySetRate} average={monthlyAverage}/>
+      <div className="flex flex-row justify-start pl-9">
+        <TriangleIcon className="w-4 h-4 mr-1 ml-2 text-blue-300" />
+        <div className='text-xs text-gray-500'>月を選択</div>
+      </div>
 
-    <WeeklyRecord monthRecords={filteredSalesRecords} />
+      <div className="flex flex-col w-full justify-center items-center px-7"> 
+        <div className="w-full items-center max-w-md p-2 md:px-3">
+          <MonthPicker value={value} setValue={setValue} />
+        </div>
+      </div>
+
+      <MonthlyRecord amount={monthlyAmount} number={monthlyNumber} count={monthlyCount} setRate={monthlySetRate} average={monthlyAverage}/>
+
+    </div>
+
+    {/* <WeeklyRecord monthRecords={filteredSalesRecords} /> */}
 
     </>
   )

--- a/app/components/page/Archive/MonthlyRecord.tsx
+++ b/app/components/page/Archive/MonthlyRecord.tsx
@@ -1,4 +1,7 @@
 import { formatCurrency } from "@/utils/currencyUtils";
+import { UserIcon,ShoppingBagIcon, CurrencyYenIcon } from "@heroicons/react/24/outline";
+import { UsersIcon } from "@heroicons/react/24/solid";
+import { SolidShirtIcon } from "../../ui/icon/ShirtIcon";
 
 type MonthlyRecordProps = {
   amount: number;
@@ -11,11 +14,40 @@ type MonthlyRecordProps = {
 export default function MonthlyRecord({amount, number, count, setRate, average} :MonthlyRecordProps) {
   return (
     <>
-      <div>トータル金額: {formatCurrency(amount)}</div>
-      <div>トータル点数: {number}</div>
-      <div>トータル客数: {count}</div>
-      <div>セット率: {setRate.toFixed(1)}</div>
-      <div>客単価: {formatCurrency(average)}</div>
+      <div className="flex flex-row justify-center items-center px-7">
+        <div className="w-1/3">
+          <div className='flex flex-col justify-center items-center text-gray-400 p-5'>
+            <CurrencyYenIcon className="w-8 h-8"/>
+            <div className='text-xs text-gray-600 mt-1'>金額</div>
+            <div className='text-lg text-gray-800 mt-1 font-bold'>{formatCurrency(amount)}</div>
+          </div>
+        </div>
+        <div className="w-1/3">
+          <div className='flex flex-col justify-center items-center text-gray-400 p-5'>
+            <ShoppingBagIcon className="w-8 h-8" />
+            <div className='text-xs text-gray-600 mt-1'>セット率</div>
+            <div className='text-lg text-gray-800 mt-1 font-bold'>{setRate.toFixed(1)}</div>
+          </div>
+        </div>
+        <div className="w-1/3">
+          <div className='flex flex-col justify-center items-center text-gray-400 p-5'>
+            <UserIcon className="w-8 h-8" />
+            <div className='text-xs text-gray-600 mt-1'>客単価</div>
+            <div className='text-lg text-gray-800 mt-1 font-bold'>{formatCurrency(average)}</div>
+          </div>
+        </div>
+      </div>
+      <div className="flex flex-row justify-end items-center px-10 mr-2 text-lg text-gray-500">
+        <div>total：</div>
+        <div className="flex flex-row ml-1">
+          <UsersIcon className="w-7 h-7 p-1 text-gray-400" />
+          <div className='text-gray-900'>{count}人</div>
+        </div>
+        <div className="flex flex-row ml-2">
+          <SolidShirtIcon className="w-6 h-7 mr-1 text-gray-400" />
+          <div className='text-gray-900'>{number}点</div>
+        </div>
+      </div>
     </>
   )
 }

--- a/app/components/page/Archive/MonthlyRecord.tsx
+++ b/app/components/page/Archive/MonthlyRecord.tsx
@@ -9,43 +9,48 @@ type MonthlyRecordProps = {
   count: number;
   setRate: number;
   average: number;
+  days: number;
 };
 
-export default function MonthlyRecord({amount, number, count, setRate, average} :MonthlyRecordProps) {
+export default function MonthlyRecord({amount, number, count, setRate, average, days} :MonthlyRecordProps) {
   return (
     <>
       <div className="flex flex-row justify-center items-center px-7 md:px-12">
         <div className="w-1/3">
           <div className='flex flex-col justify-center items-center text-gray-400 p-5'>
             <CurrencyYenIcon className="w-8 h-8"/>
-            <div className='text-xs text-gray-600 mt-1'>金額</div>
-            <div className='text-lg text-gray-800 mt-1 font-bold'>{formatCurrency(amount)}</div>
+            <div className='text-xs md:text-sm text-gray-600 mt-1'>売上金額</div>
+            <div className='text-md md:text-lg text-gray-800 mt-1 font-bold'>{formatCurrency(amount)}</div>
           </div>
         </div>
         <div className="w-1/3">
           <div className='flex flex-col justify-center items-center text-gray-400 p-5'>
             <ShoppingBagIcon className="w-8 h-8" />
-            <div className='text-xs text-gray-600 mt-1'>セット率</div>
-            <div className='text-lg text-gray-800 mt-1 font-bold'>{setRate.toFixed(1)}</div>
+            <div className='text-xs md:text-sm text-gray-600 mt-1'>セット率</div>
+            <div className='text-md md:text-lg text-gray-800 mt-1 font-bold'>{setRate.toFixed(1)}</div>
           </div>
         </div>
         <div className="w-1/3">
           <div className='flex flex-col justify-center items-center text-gray-400 p-5'>
             <UserIcon className="w-8 h-8" />
-            <div className='text-xs text-gray-600 mt-1'>客単価</div>
-            <div className='text-lg text-gray-800 mt-1 font-bold'>{formatCurrency(average)}</div>
+            <div className='text-xs md:text-sm text-gray-600 mt-1'>客単価</div>
+            <div className='text-md md:text-lg text-gray-800 mt-1 font-bold'>{formatCurrency(average)}</div>
           </div>
         </div>
       </div>
-      <div className="flex flex-row justify-end items-center px-10 md:px-12 mr-2 text-lg text-gray-500">
-        <div>total：</div>
-        <div className="flex flex-row ml-1">
-          <UsersIcon className="w-7 h-7 p-1 text-gray-400" />
-          <div className='text-gray-900'>{count}人</div>
+      <div className="flex flex-row justify-center md:justify-end items-center px-10 md:px-12 md:mr-5 text-md md:text-lg text-gray-600">
+        <div className='text-gray-700 font-bold'>{days}</div>
+        <div className='text-gray-700 ml-1'>days</div>
+        <div className='text-gray-700 ml-2'>total：</div>
+        <div className="flex flex-row ml-2">
+          <UsersIcon className="w-6 h-6 p-1 text-gray-400" />
+          <div className='text-gray-700 font-bold'>{count}</div>
+          <div className='text-gray-700'>人</div>
         </div>
         <div className="flex flex-row ml-2">
-          <SolidShirtIcon className="w-6 h-7 mr-1 text-gray-400" />
-          <div className='text-gray-900'>{number}点</div>
+          <SolidShirtIcon className="w-5 h-6 mr-1 text-gray-400" />
+          <div className='text-gray-700 font-bold'>{number}</div>
+          <div className='text-gray-700'>点</div>
         </div>
       </div>
     </>

--- a/app/components/page/Archive/MonthlyRecord.tsx
+++ b/app/components/page/Archive/MonthlyRecord.tsx
@@ -14,7 +14,7 @@ type MonthlyRecordProps = {
 export default function MonthlyRecord({amount, number, count, setRate, average} :MonthlyRecordProps) {
   return (
     <>
-      <div className="flex flex-row justify-center items-center px-7">
+      <div className="flex flex-row justify-center items-center px-7 md:px-12">
         <div className="w-1/3">
           <div className='flex flex-col justify-center items-center text-gray-400 p-5'>
             <CurrencyYenIcon className="w-8 h-8"/>
@@ -37,7 +37,7 @@ export default function MonthlyRecord({amount, number, count, setRate, average} 
           </div>
         </div>
       </div>
-      <div className="flex flex-row justify-end items-center px-10 mr-2 text-lg text-gray-500">
+      <div className="flex flex-row justify-end items-center px-10 md:px-12 mr-2 text-lg text-gray-500">
         <div>total：</div>
         <div className="flex flex-row ml-1">
           <UsersIcon className="w-7 h-7 p-1 text-gray-400" />

--- a/app/components/page/Archive/WeeklyArchive.tsx
+++ b/app/components/page/Archive/WeeklyArchive.tsx
@@ -1,15 +1,15 @@
 import { SalesRecord, WeeklyRecord } from "@/types";
 import { getWeekHead, getweekEndDate, sortData } from "@/utils/dateUtils";
 import { calculateSetRate, calculateAverage } from "@/utils/calculateUtils";
-import { formatCurrency } from "@/utils/currencyUtils";
 import { Accordion } from '@mantine/core';
-import { CheckBadgeIcon, ClipboardDocumentListIcon } from "@heroicons/react/24/outline";
+import { ClipboardDocumentListIcon } from "@heroicons/react/24/outline";
+import WeeklyRecordContents from "./WeeklyRecordContents";
 
 type WeeklyRecordProps = {
   monthRecords: SalesRecord[];
 };
 
-export default function WeeklyRecord({monthRecords} :WeeklyRecordProps) {
+export default function WeeklyArchive({monthRecords} :WeeklyRecordProps) {
 
   const weeklyData = monthRecords.reduce<Record<string, WeeklyRecord>>((acc, record) => {
     const weekHead = getWeekHead(record.date);
@@ -37,17 +37,19 @@ export default function WeeklyRecord({monthRecords} :WeeklyRecordProps) {
             
             <Accordion.Item key={weekKey} value={weekKey}>
               <Accordion.Control
-                icon={ <ClipboardDocumentListIcon className="w-6 h-6 text-blue-300"/>
+                icon={ <ClipboardDocumentListIcon className="w-6 h-6 ml-2 text-blue-300"/>
                 }
               >
                 {weekKey} 〜 {weeklyData[weekKey].weekEnd}
               </Accordion.Control>
               <Accordion.Panel>
-                <div>金額: {formatCurrency(weeklyData[weekKey].amount)}</div>
-                <div>点数: {weeklyData[weekKey].number}</div>
-                <div>客数: {weeklyData[weekKey].count}</div>
-                <div>セット率: {weeklyData[weekKey].setRate.toFixed(1)}</div>
-                <div>客単価: {formatCurrency(weeklyData[weekKey].average)}</div>
+                <WeeklyRecordContents 
+                  amount={weeklyData[weekKey].amount} 
+                  number={weeklyData[weekKey].number}
+                  count={weeklyData[weekKey].count}
+                  setRate={weeklyData[weekKey].setRate}
+                  average={weeklyData[weekKey].average}
+                  />
               </Accordion.Panel>
             </Accordion.Item>
           ))}

--- a/app/components/page/Archive/WeeklyRecord.tsx
+++ b/app/components/page/Archive/WeeklyRecord.tsx
@@ -1,50 +1,58 @@
-import { SalesRecord } from "@/types";
-import { getWeekHead, sortData } from "@/utils/dateUtils";
+import { SalesRecord, WeeklyRecord } from "@/types";
+import { getWeekHead, getweekEndDate, sortData } from "@/utils/dateUtils";
 import { calculateSetRate, calculateAverage } from "@/utils/calculateUtils";
 import { formatCurrency } from "@/utils/currencyUtils";
+import { Accordion } from '@mantine/core';
+import { CheckBadgeIcon, ClipboardDocumentListIcon } from "@heroicons/react/24/outline";
 
 type WeeklyRecordProps = {
   monthRecords: SalesRecord[];
 };
 
-type WeeklyData = {
-  amount: number;
-  number: number;
-  count: number;
-  setRate: number;
-  average: number;
-};
-
 export default function WeeklyRecord({monthRecords} :WeeklyRecordProps) {
 
-  const weeklyData = monthRecords.reduce<Record<string, WeeklyData>>((acc, record) => {
+  const weeklyData = monthRecords.reduce<Record<string, WeeklyRecord>>((acc, record) => {
     const weekHead = getWeekHead(record.date);
     if (!acc[weekHead]) {
-        acc[weekHead] = { amount: 0, number: 0, count: 0, setRate: 0, average: 0 };
-      }
-        acc[weekHead].amount += record.total_amount;
-        acc[weekHead].number += record.total_number;
-        acc[weekHead].count += record.count;
+      acc[weekHead] = { amount: 0, number: 0, count: 0, setRate: 0, average: 0, weekEnd: '' };
+    }
+    acc[weekHead].amount += record.total_amount;
+    acc[weekHead].number += record.total_number;
+    acc[weekHead].count += record.count;
         
-        acc[weekHead].setRate = calculateSetRate(acc[weekHead].number, acc[weekHead].count)
-        acc[weekHead].average = calculateAverage(acc[weekHead].amount, acc[weekHead].count)
-        return acc;
+    acc[weekHead].setRate = calculateSetRate(acc[weekHead].number, acc[weekHead].count)
+    acc[weekHead].average = calculateAverage(acc[weekHead].amount, acc[weekHead].count)
+
+    acc[weekHead].weekEnd = getweekEndDate(weekHead);
+    return acc;
   }, {});
 
   const sortedWeeklyData = sortData(weeklyData);
 
   return (
     <>
-    {sortedWeeklyData.map(weekKey => (
-      <div key={weekKey}>
-        <div>{weekKey} 〜</div>
-        <div>金額: {formatCurrency(weeklyData[weekKey].amount)}</div>
-        <div>点数: {weeklyData[weekKey].number}</div>
-        <div>客数: {weeklyData[weekKey].count}</div>
-        <div>セット率: {weeklyData[weekKey].setRate.toFixed(1)}</div>
-        <div>客単価: {formatCurrency(weeklyData[weekKey].average)}</div>
+      <div className="px-9 pt-4">
+        <Accordion variant="contained">
+          {sortedWeeklyData.map(weekKey => (
+            
+            <Accordion.Item key={weekKey} value={weekKey}>
+              <Accordion.Control
+                icon={ <ClipboardDocumentListIcon className="w-6 h-6 text-blue-300"/>
+                }
+              >
+                {weekKey} 〜 {weeklyData[weekKey].weekEnd}
+              </Accordion.Control>
+              <Accordion.Panel>
+                <div>金額: {formatCurrency(weeklyData[weekKey].amount)}</div>
+                <div>点数: {weeklyData[weekKey].number}</div>
+                <div>客数: {weeklyData[weekKey].count}</div>
+                <div>セット率: {weeklyData[weekKey].setRate.toFixed(1)}</div>
+                <div>客単価: {formatCurrency(weeklyData[weekKey].average)}</div>
+              </Accordion.Panel>
+            </Accordion.Item>
+          ))}
+        </Accordion>
       </div>
-    ))}
     </>
   )
 }

--- a/app/components/page/Archive/WeeklyRecordContents.tsx
+++ b/app/components/page/Archive/WeeklyRecordContents.tsx
@@ -1,0 +1,48 @@
+import { formatCurrency } from "@/utils/currencyUtils";
+import { UserIcon,ShoppingBagIcon, CurrencyYenIcon } from "@heroicons/react/24/outline";
+import { UsersIcon } from "@heroicons/react/24/solid";
+import { SolidShirtIcon } from "../../ui/icon/ShirtIcon";
+
+type WeeklyRecordContents = {
+  amount: number;
+  number: number;
+  count: number;
+  setRate: number
+  average: number;
+}
+
+export default function WeeklyRecordContents({ amount, number, count, setRate, average}: WeeklyRecordContents) {
+  return (
+    <div className="p-2">
+      <div className="flex items-center text-gray-700">
+        <CurrencyYenIcon className="w-6 h-6 text-sky-800 mr-2" />
+        売上金額
+      </div>
+      <div className="py-1 ml-8 text-md text-gray-700 font-bold">{formatCurrency(amount)}</div>
+      <div className="flex items-center text-gray-700 border-t mt-2 pt-3">
+        <ShoppingBagIcon className="w-6 h-6 text-sky-800 mr-2"/>
+        セット率
+      </div>
+      <div className="flex flex-row">
+        <div className="py-1 ml-8 text-gray-700 text-md font-bold">{setRate.toFixed(1)}</div>
+        <div className="flex flex-row items-center py-1 ml-8 text-lg font-bold text-gray-600">
+          <p className="px-4">/</p>
+          <div><SolidShirtIcon className="w-5 h-5 text-gray-600 mr-2" /></div>
+          <p>{number} 点</p>
+        </div>
+      </div>
+      <div className="flex flex-row items-center text-gray-700 border-t mt-2 pt-3">
+        <UserIcon className="w-6 h-6 text-sky-800 mr-2" />
+        客単価
+      </div>
+      <div className="flex flex-row">
+        <div className="py-1 ml-8 text-gray-700 text-md font-bold">{formatCurrency(average)}</div>
+        <div className="flex flex-row items-center py-1 ml-8 text-lg font-bold text-gray-600">
+          <p className="px-4">/</p>
+          <div><UsersIcon  className="w-5 h-5 text-gray-600 mr-2"/></div>
+          <p>{count} 人</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/components/page/DairyRecord/CustomersHoverCard.tsx
+++ b/app/components/page/DairyRecord/CustomersHoverCard.tsx
@@ -1,5 +1,5 @@
 import { HoverCard, Text, Group, ActionIcon  } from '@mantine/core';
-import { UsersIcon } from "@heroicons/react/24/outline";
+import { CursorArrowRaysIcon } from "@heroicons/react/24/outline";
 import CustomersList from './CustomersList';
 
 export default function CustomersHoverCard() {
@@ -7,8 +7,8 @@ export default function CustomersHoverCard() {
     <Group justify="center">
       <HoverCard width={280} shadow="md">
         <HoverCard.Target>
-          <ActionIcon variant="light" size="lg" color="#60a5fa" radius="xl" aria-label="Settings" className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform">
-            <UsersIcon className="w-10 h-10 m-1 p-1"/>
+          <ActionIcon variant="outline" size="lg" color="#e2e8f0" radius="md" aria-label="Settings" className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform">
+            <CursorArrowRaysIcon className="w-5 h-5 text-blue-300 hover:text-sky-700"/>
           </ActionIcon>
         </HoverCard.Target>
         <HoverCard.Dropdown>

--- a/app/components/page/DashBoard/CreateTarget.tsx
+++ b/app/components/page/DashBoard/CreateTarget.tsx
@@ -9,7 +9,7 @@ export default function CreateTarget() {
 
   return (
     <>
-      <Button size="xs" variant="outline" color="#64748b" onClick={open}>
+      <Button size="xs" variant="outline" color="#94a3b8" onClick={open} className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform">
         登録する
         <CursorArrowRaysIcon className="w-5 h-5 ml-1 text-blue-400" />
       </Button>

--- a/app/components/page/DashBoard/JobsInput.tsx
+++ b/app/components/page/DashBoard/JobsInput.tsx
@@ -47,12 +47,12 @@ export default function JobsInput({data, jobs, setJobs}: JobsInputProps) {
       />
       <div className='flex flex-row ml-2'>
         <div>
-          <ActionIcon variant="filled" color="#93c5fd" size="lg" onClick={addData} className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform">
+          <ActionIcon variant="outline" color="#93c5fd" size="lg" onClick={addData} className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform">
             <PlusIcon className='w-12 h-12 p-1' />
           </ActionIcon>
         </div>
         <div className='ml-2'>
-          <ActionIcon variant="filled" color="#cbd5e1" size="lg" onClick={clearData} className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform">
+          <ActionIcon variant="outline" color="#cbd5e1" size="lg" onClick={clearData} className="shadow-md hover:translate-y-1 hover:text-gray-500 transition-transform">
             <TrashIcon className='w-12 h-12 p-1' />
           </ActionIcon>
         </div>

--- a/app/components/page/DashBoard/TargetInput.tsx
+++ b/app/components/page/DashBoard/TargetInput.tsx
@@ -40,6 +40,8 @@ export default function TargetInput({close} :TargetInputProps) {
         showErrorNotification('目標の登録に失敗しました');
         console.error("Failed to send weekly target", error);
       }
+    } else {
+      showErrorNotification('目標を入力してください');
     }
   };
 

--- a/app/components/page/StepForm/Achievements.tsx
+++ b/app/components/page/StepForm/Achievements.tsx
@@ -41,14 +41,14 @@ export default function Achievements() {
             <div className="md:pl-2 md:border-l border-gray-400">詳しい実績をみる</div>
             <div className="ml-2">
               <ActionIcon
-                variant="white"
+                variant="outline"
                 size="lg"
-                color="#60a5fa"
+                color="#e2e8f0"
                 aria-label="Settings" 
                 className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform"
                 onClick={open}
               >
-                <CursorArrowRaysIcon className="w-8 h-8 p-1"/>
+                <CursorArrowRaysIcon className="w-8 h-8 p-1 text-blue-300 hover:text-sky-700"/>
               </ActionIcon>
             </div>
           </div>

--- a/app/components/ui/Breadcrumbs.tsx
+++ b/app/components/ui/Breadcrumbs.tsx
@@ -1,0 +1,22 @@
+"use client"
+import { useRouter } from 'next/navigation'
+import { HomeIcon } from "@heroicons/react/24/outline";
+
+type BreadcrumbsProps = {
+  children: string;
+}
+
+export default function Breadcrumbs({ children }: BreadcrumbsProps) {
+  const router = useRouter()
+
+  return (
+    <div className='flex flex-row items-center px-2 pt-4 max-w-lg mx-auto'>
+      <div className='flex flex-row text-gray-400 items-center hover:underline hover:text-sky-800 cursor-pointer' onClick={() => router.push('/dashboard')}>
+        <HomeIcon className="w-4 h-4 mr-1" />
+        <div>dashboard</div>
+      </div>
+      <div className='text-xs text-gray-400 mx-2'>＜</div>
+      <div className='text-sky-700 cursor-pointer'>{children}</div>
+    </div>
+  )
+}

--- a/app/components/ui/MonthPicker.tsx
+++ b/app/components/ui/MonthPicker.tsx
@@ -14,8 +14,8 @@ export default function MonthPicker({value, setValue} :MonthPickerProps ) {
     <MonthPickerInput
       leftSection={icon}
       leftSectionPointerEvents="none"
-      label="Pick date"
       placeholder="Pick date"
+      valueFormat= "YYYY年 MM月"
       value={value}
       onChange={setValue}
     />

--- a/app/components/ui/icon/ShirtIcon.tsx
+++ b/app/components/ui/icon/ShirtIcon.tsx
@@ -13,7 +13,7 @@ export function ShirtIcon({ className }: IconProps ) {
 
 export function SolidShirtIcon({ className }: IconProps ) {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" className={`icon icon-tabler icon-tabler-shirt ${className}`} width="44" height="44" viewBox="0 0 24 24" strokeWidth="1.5" stroke="#6b7280" fill="currentColor" strokeLinecap="round" strokeLinejoin="round">
+    <svg xmlns="http://www.w3.org/2000/svg" className={`icon icon-tabler icon-tabler-shirt ${className}`} width="44" height="44" viewBox="0 0 24 24" strokeWidth="1.5" stroke="none" fill="currentColor" strokeLinecap="round" strokeLinejoin="round">
       <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
       <path d="M15 4l6 2v5h-3v8a1 1 0 0 1 -1 1h-10a1 1 0 0 1 -1 -1v-8h-3v-5l6 -2a3 3 0 0 0 6 0" />
     </svg>

--- a/app/components/ui/icon/Triangle.tsx
+++ b/app/components/ui/icon/Triangle.tsx
@@ -4,7 +4,7 @@ type IconProps = {
   
 export function TriangleIcon({ className }: IconProps ) {
   return (
-    <svg xmlns="http://www.w3.org/2000/svg" className={`icon icon-tabler icon-tabler-triangle-inverted-filled ${className}`} width="44" height="44" viewBox="0 0 24 24" strokeWidth="1.5" stroke="#6b7280" fill="none" strokeLinecap="round" strokeLinejoin="round">
+    <svg xmlns="http://www.w3.org/2000/svg" className={`icon icon-tabler icon-tabler-triangle-inverted-filled ${className}`} width="44" height="44" viewBox="0 0 24 24" strokeWidth="1.5" stroke="none" fill="none" strokeLinecap="round" strokeLinejoin="round">
       <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
       <path d="M20.118 3h-16.225a2.914 2.914 0 0 0 -2.503 4.371l8.116 13.549a2.917 2.917 0 0 0 4.987 .005l8.11 -13.539a2.914 2.914 0 0 0 -2.486 -4.386z" strokeWidth="0" fill="currentColor" />
     </svg>

--- a/types/index.ts
+++ b/types/index.ts
@@ -19,6 +19,15 @@ export type WeeklyReport = {
     end_date: string;
 };
 
+export type WeeklyRecord = {
+    amount: number;
+    number: number;
+    count: number;
+    setRate: number;
+    average: number;
+    weekEnd: string;
+};
+
 export type ResisteredDateRange = {
     startDate: string;
     endDate: string;

--- a/utils/dateUtils.ts
+++ b/utils/dateUtils.ts
@@ -62,6 +62,10 @@ export const getWeekHead = (date :string) => {
   return dayjs(date).startOf('isoWeek').format('MM / DD');
 }
 
+export const getweekEndDate = (date :string) => {
+  return dayjs(date).add(6, 'day').format('MM / DD');
+}
+
 export const formatDateMD = (date :string) => {
   return dayjs(date).format("MM/DD");
 };


### PR DESCRIPTION
## 概要

算出した月間、週間毎のデータの表示ページを作成。
issue #45 で算出したデータに加え日数の取得を追加。

issue: #46 

その他：
色の反映されてないボタンの修正
入力不備時のNotification設定漏れの修正

## 変更点

- archiveページの見た目の実装
- ダッシュボードに戻るパンくずコンポーネントを作成（グラフ、レポート一覧ページで再利用）

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0
- 期待する動作とレイアウトの反映を確認

## 影響範囲
- /dashboard
- /archive

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応

## コメント
