### PR TITLE
Fix archive

### DIFF
--- a/app/components/page/Archive/MonthlyArchive.tsx
+++ b/app/components/page/Archive/MonthlyArchive.tsx
@@ -41,13 +41,19 @@ export default function MonthlyArchive() {
         <div className='text-sm text-gray-800'>月を選択</div>
       </div>
 
-      <div className="flex flex-col w-full justify-center items-center px-7 md:px-12"> 
+      <div className="flex flex-col w-full justify-center items-center px-5 md:px-12"> 
         <div className="w-full items-center max-w-md px-3 py-2">
           <MonthPicker value={value} setValue={setValue} />
         </div>
       </div>
 
       <MonthlyRecord amount={monthlyAmount} number={monthlyNumber} count={monthlyCount} setRate={monthlySetRate} average={monthlyAverage} days={numberOfDays}/>
+
+      <div className="flex flex-row justify-start px-7 pt-5 pb-2 md:px-12">
+        <TriangleIcon className="w-4 h-4 mr-1 ml-4 text-blue-300" />
+        <div className='text-sm text-gray-800'>各週のデータ</div>
+      </div>
+
       <WeeklyArchive monthRecords={filteredSalesRecords} />
     </div>    
     </>

--- a/app/components/page/Archive/MonthlyArchive.tsx
+++ b/app/components/page/Archive/MonthlyArchive.tsx
@@ -34,7 +34,7 @@ export default function MonthlyArchive() {
 
   return (
     <>
-    <div className="flex flex-col justify-center w-full max-w-lg py-7 bg-white rounded-md">
+    <div className="flex flex-col justify-center w-full max-w-lg pt-4 pb-7 md:py-7 bg-white rounded-md">
 
       <div className="flex flex-row justify-start px-7 pt-2 md:px-12">
         <TriangleIcon className="w-4 h-4 mr-1 ml-4 text-blue-300" />

--- a/app/components/page/Archive/MonthlyRecord.tsx
+++ b/app/components/page/Archive/MonthlyRecord.tsx
@@ -38,7 +38,7 @@ export default function MonthlyRecord({amount, number, count, setRate, average, 
           </div>
         </div>
       </div>
-      <div className="flex flex-row justify-center md:justify-end items-center px-10 md:px-12 md:mr-5 text-md md:text-lg text-gray-600">
+      <div className="flex flex-row justify-center md:justify-end items-center px-10 md:px-12 md:mr-5 text-md md:text-lg text-gray-600 pb-4">
         <div className='text-gray-700 font-bold'>{days}</div>
         <div className='text-gray-700 ml-1'>days</div>
         <div className='text-gray-700 ml-2'>total：</div>

--- a/app/components/page/Archive/WeeklyArchive.tsx
+++ b/app/components/page/Archive/WeeklyArchive.tsx
@@ -1,5 +1,5 @@
 import { SalesRecord, WeeklyRecord } from "@/types";
-import { getWeekHead, getweekEndDate, sortData } from "@/utils/dateUtils";
+import { getWeekHead, getweekEndDate, sortData, formatDateLayoutMD } from "@/utils/dateUtils";
 import { calculateSetRate, calculateAverage } from "@/utils/calculateUtils";
 import { Accordion } from '@mantine/core';
 import { ClipboardDocumentListIcon } from "@heroicons/react/24/outline";
@@ -13,6 +13,8 @@ export default function WeeklyArchive({monthRecords} :WeeklyRecordProps) {
 
   const weeklyData = monthRecords.reduce<Record<string, WeeklyRecord>>((acc, record) => {
     const weekHead = getWeekHead(record.date);
+    const weekEnd = getweekEndDate(weekHead);
+
     if (!acc[weekHead]) {
       acc[weekHead] = { amount: 0, number: 0, count: 0, setRate: 0, average: 0, weekEnd: '' };
     }
@@ -22,8 +24,8 @@ export default function WeeklyArchive({monthRecords} :WeeklyRecordProps) {
         
     acc[weekHead].setRate = calculateSetRate(acc[weekHead].number, acc[weekHead].count)
     acc[weekHead].average = calculateAverage(acc[weekHead].amount, acc[weekHead].count)
-
-    acc[weekHead].weekEnd = getweekEndDate(weekHead);
+    acc[weekHead].weekEnd = weekEnd;
+    
     return acc;
   }, {});
 
@@ -40,7 +42,7 @@ export default function WeeklyArchive({monthRecords} :WeeklyRecordProps) {
                 icon={ <ClipboardDocumentListIcon className="w-6 h-6 ml-2 text-blue-300"/>
                 }
               >
-                {weekKey} 〜 {weeklyData[weekKey].weekEnd}
+                {formatDateLayoutMD(weekKey)} 〜 {formatDateLayoutMD(weeklyData[weekKey].weekEnd)}
               </Accordion.Control>
               <Accordion.Panel>
                 <WeeklyRecordContents 

--- a/app/components/page/Archive/WeeklyArchive.tsx
+++ b/app/components/page/Archive/WeeklyArchive.tsx
@@ -33,7 +33,7 @@ export default function WeeklyArchive({monthRecords} :WeeklyRecordProps) {
 
   return (
     <>
-      <div className="px-9 pt-4">
+      <div className="px-7 md:px-12">
         <Accordion variant="contained">
           {sortedWeeklyData.map(weekKey => (
             

--- a/app/components/page/Archive/WeeklyRecordContents.tsx
+++ b/app/components/page/Archive/WeeklyRecordContents.tsx
@@ -25,8 +25,8 @@ export default function WeeklyRecordContents({ amount, number, count, setRate, a
       </div>
       <div className="flex flex-row">
         <div className="py-1 ml-8 text-gray-700 text-md font-bold">{setRate.toFixed(1)}</div>
-        <div className="flex flex-row items-center py-1 ml-8 text-lg font-bold text-gray-600">
-          <p className="px-4">/</p>
+        <div className="flex flex-row items-center py-1 text-lg font-bold text-gray-600">
+          <p className="px-4 md:px-5">/</p>
           <div><SolidShirtIcon className="w-5 h-5 text-gray-600 mr-2" /></div>
           <p>{number} 点</p>
         </div>
@@ -37,8 +37,8 @@ export default function WeeklyRecordContents({ amount, number, count, setRate, a
       </div>
       <div className="flex flex-row">
         <div className="py-1 ml-8 text-gray-700 text-md font-bold">{formatCurrency(average)}</div>
-        <div className="flex flex-row items-center py-1 ml-8 text-lg font-bold text-gray-600">
-          <p className="px-4">/</p>
+        <div className="flex flex-row items-center py-1 text-lg font-bold text-gray-600">
+          <p className="px-2 md:px-5">/</p>
           <div><UsersIcon  className="w-5 h-5 text-gray-600 mr-2"/></div>
           <p>{count} 人</p>
         </div>

--- a/app/components/ui/Breadcrumbs.tsx
+++ b/app/components/ui/Breadcrumbs.tsx
@@ -10,7 +10,7 @@ export default function Breadcrumbs({ children }: BreadcrumbsProps) {
   const router = useRouter()
 
   return (
-    <div className='flex flex-row items-center px-2 pt-4 max-w-lg mx-auto'>
+    <div className='flex flex-row items-center px-2 pt-4 max-w-xs md:max-w-lg mx-auto'>
       <div className='flex flex-row text-gray-400 items-center hover:underline hover:text-sky-800 cursor-pointer' onClick={() => router.push('/dashboard')}>
         <HomeIcon className="w-4 h-4 mr-1" />
         <div>dashboard</div>

--- a/utils/dateUtils.ts
+++ b/utils/dateUtils.ts
@@ -59,15 +59,19 @@ export const getThisWeekRange = () => {
 
 // string型で受け取る
 export const getWeekHead = (date :string) => {
-  return dayjs(date).startOf('isoWeek').format('MM / DD');
+  return dayjs(date).startOf('isoWeek').format('YYYY-MM-DD');
 }
 
 export const getweekEndDate = (date :string) => {
-  return dayjs(date).add(6, 'day').format('MM / DD');
+  return dayjs(date).endOf('isoWeek').format('YYYY-MM-DD');
 }
 
 export const formatDateMD = (date :string) => {
   return dayjs(date).format("MM/DD");
+};
+
+export const formatDateLayoutMD = (date :string) => {
+  return dayjs(date).format("MM / DD");
 };
 
 export const sortData = (data: Record<string, any>) => {


### PR DESCRIPTION
## 概要

週末が正く取得できない問題の修正
スマホ時のレイアウト崩れの修正
issue: #68 

## 変更点

- dayjsに渡す形式を変更
- 余白の調整など

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0
- 開発環境で正く表示される状態

## 影響範囲
- /archive

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応
