### PR TITLE
Job_validation #69

### DIFF
--- a/app/components/page/DashBoard/JobsInput.tsx
+++ b/app/components/page/DashBoard/JobsInput.tsx
@@ -44,10 +44,11 @@ export default function JobsInput({data, jobs, setJobs}: JobsInputProps) {
         data={filteredData}
         value={value}
         onChange={setValue}
+        disabled={jobs.length >= 3}
       />
       <div className='flex flex-row ml-2'>
         <div>
-          <ActionIcon variant="outline" color="#93c5fd" size="lg" onClick={addData} className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform">
+          <ActionIcon variant="outline" color="#93c5fd" disabled={jobs.length >= 3} size="lg" onClick={addData} className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform">
             <PlusIcon className='w-12 h-12 p-1' />
           </ActionIcon>
         </div>

--- a/app/components/page/DashBoard/NotJobRecord.tsx
+++ b/app/components/page/DashBoard/NotJobRecord.tsx
@@ -23,7 +23,7 @@ export default function NotJobRecord({ selectedDate, close } :NotJobRecordProps)
   const { fetchJobsRecord } = useDashboardStore((state) => ({fetchJobsRecord: state.fetchJobsRecord}));
 
   const handleSubmit = async () => {
-    if (selectedDate !== null && jobs.length !== 0 ) {
+    if (selectedDate !== null && jobs.length !== 0 && jobs.length < 4 ) {
       try {
         await axios.post(`/api/jobrecord`, {
           job_record: {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import { Viewport } from 'next'
 import { NextAuthProvider } from '../providers/NextAuth'
 import { MantineProviderWrapper } from '../providers/MantineProvider';
 import Footer from './components/base/Footer';
@@ -7,6 +8,12 @@ import './globals.css'
 
 export const metadata: Metadata = {
   title: 'sales buddy',
+}
+
+export const viewport: Viewport = {
+  initialScale: 1.0,
+  width: 'device-width',
+  maximumScale: 1.0,
 }
 
 export default function RootLayout({


### PR DESCRIPTION
## 概要

業務を３つ以上追加できないように修正。
issue: #69 

## 変更点

- 3つ追加された時点でフォームと追加ボタンをdisabledにする
- handleSunbmit関数でも条件を追加

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0

３つ以上で登録ボタンを押せないことを確認

## 影響範囲
- /dashboard

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応