### PR TITLE
Customer Graph #50

### DIFF
--- a/app/(authenticated)/customergraph/page.tsx
+++ b/app/(authenticated)/customergraph/page.tsx
@@ -1,0 +1,9 @@
+import CustomersPie from '@/app/components/page/CustomerGraph/CustomersPie'
+
+export default function page() {
+  return (
+    <div>
+      <CustomersPie />
+    </div>
+  )
+}

--- a/app/(authenticated)/customergraph/page.tsx
+++ b/app/(authenticated)/customergraph/page.tsx
@@ -1,9 +1,13 @@
-import CustomersPie from '@/app/components/page/CustomerGraph/CustomersPie'
+import Breadcrumbs from '@/app/components/ui/Breadcrumbs'
+import GraphArea from '@/app/components/page/CustomerGraph/GraphArea'
 
 export default function page() {
   return (
-    <div>
-      <CustomersPie />
-    </div>
+    <>
+      <Breadcrumbs>customers graph</Breadcrumbs>
+      <div className="flex flex-col justify-center items-center mx-auto px-6 z-0 max-w-4xl mb-7 mt-4">
+        <GraphArea/>
+      </div>
+    </>
   )
 }

--- a/app/api/customers/route.ts
+++ b/app/api/customers/route.ts
@@ -1,0 +1,43 @@
+import axios from 'axios';
+import { getServerSession } from "next-auth/next"
+import { options } from '@/lib/options';
+
+export async function GET()  {
+
+  const session = await getServerSession(options);
+    
+  if (!session) {
+    return new Response(JSON.stringify({ error: '認証が必要です' }), {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  const railsUserId = session.user.railsId;
+  const apiUrl = process.env.RAILS_API_URL
+
+  try {
+    const response = await axios.get(`${apiUrl}/customer_records`, {
+      headers: {
+        'user': `${railsUserId}`,
+        'Content-Type': 'application/json',
+      },
+    });
+    return new Response(JSON.stringify(response.data), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    return new Response(JSON.stringify({ error:'予期せぬエラーが発生しました' }), {
+      status: 500,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+}

--- a/app/components/page/Archive/MonthlyArchive.tsx
+++ b/app/components/page/Archive/MonthlyArchive.tsx
@@ -1,6 +1,6 @@
 "use client"
 import { useState } from "react";
-import { useFetchResisterdDay } from "@/lib/useFetchData";
+import { useFetchForArchive } from "@/lib/useFetchData";
 import { formatDateYM } from "@/utils/dateUtils";
 import { calculateTotal, calculateSetRate, calculateAverage } from "@/utils/calculateUtils";
 import useDashboardStore from "@/store/dashboardStore";
@@ -11,7 +11,7 @@ import { TriangleIcon } from "../../ui/icon/Triangle";
 
 export default function MonthlyArchive() {
 
-  useFetchResisterdDay();
+  useFetchForArchive();
 
   const { salesRecords } = useDashboardStore();
   const [value, setValue] = useState<Date | null>(new Date());

--- a/app/components/page/CustomerGraph/CustomersPie.tsx
+++ b/app/components/page/CustomerGraph/CustomersPie.tsx
@@ -3,20 +3,9 @@ import { useState } from 'react';
 import { PieChart, Pie, Sector, Cell, ResponsiveContainer } from 'recharts';
 import useDashboardStore from '@/store/dashboardStore';
 import useCalculationStore from '@/store/calculationStore';
-import { useFetchCustomerRecords } from '@/lib/useFetchData';
+import { useFetchForCustomersGraph } from '@/lib/useFetchData';
 
-// const data = [
-//   { name: '主婦', value: 25 },
-//   { name: 'OL', value: 15 },
-//   { name: '~30代', value: 10 },
-//   { name: '〜50代', value: 5 },
-//   { name: '学生', value: 5 },
-//   { name: '顧客', value: 7 },
-//   { name: 'ギフト', value: 3 },
-//   { name: 'その他', value: 30 },
-// ];
-
-const COLORS = [ '#0369a1', '#60a5fa','#93c5fd','#bfdbfe', '#dbeafe','#cbd5e1', '#e0e7ff','#c7d2fe'];
+const COLORS = ['#60a5fa', '#93c5fd','#bfdbfe', '#cbd5e1', '#94a3b8', '#075985', '#0369a1', '#0284c7','#3b82f6' ];
 
 const renderActiveShape = (props :any) => {
   const RADIAN = Math.PI / 180;
@@ -65,7 +54,7 @@ const renderActiveShape = (props :any) => {
 };
 
 export default function CustomersPie() {
-  useFetchCustomerRecords();
+  useFetchForCustomersGraph();
 
   const [activeIndex, setActiveIndex] = useState(0);
   const { options } = useCalculationStore();
@@ -83,23 +72,27 @@ export default function CustomersPie() {
   };
 
   return (
-    <PieChart width={800} height={400}>
-      <Pie
-        activeIndex={activeIndex}
-        activeShape={renderActiveShape}
-        data={chartData}
-        cx={400}
-        cy={200}
-        innerRadius={60}
-        outerRadius={80}
-        fill="#8884d8"
-        dataKey="value"
-        onMouseEnter={onPieEnter}
-      >
-        {chartData.map((entry, index) => (
-          <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-        ))}
-      </Pie>
-    </PieChart>
+
+
+      <div style={{ width: '100%', height: 300 }}>
+        <ResponsiveContainer>
+          <PieChart>
+            <Pie
+              activeIndex={activeIndex}
+              activeShape={renderActiveShape}
+              data={chartData}
+              innerRadius={60}
+              outerRadius={80}
+              fill="#8884d8"
+              dataKey="value"
+              onMouseEnter={onPieEnter}
+            >
+              {chartData.map((entry, index) => (
+                <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+              ))}
+            </Pie>
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
   );
 }

--- a/app/components/page/CustomerGraph/CustomersPie.tsx
+++ b/app/components/page/CustomerGraph/CustomersPie.tsx
@@ -1,0 +1,105 @@
+"use client"
+import { useState } from 'react';
+import { PieChart, Pie, Sector, Cell, ResponsiveContainer } from 'recharts';
+import useDashboardStore from '@/store/dashboardStore';
+import useCalculationStore from '@/store/calculationStore';
+import { useFetchCustomerRecords } from '@/lib/useFetchData';
+
+// const data = [
+//   { name: '主婦', value: 25 },
+//   { name: 'OL', value: 15 },
+//   { name: '~30代', value: 10 },
+//   { name: '〜50代', value: 5 },
+//   { name: '学生', value: 5 },
+//   { name: '顧客', value: 7 },
+//   { name: 'ギフト', value: 3 },
+//   { name: 'その他', value: 30 },
+// ];
+
+const COLORS = [ '#0369a1', '#60a5fa','#93c5fd','#bfdbfe', '#dbeafe','#cbd5e1', '#e0e7ff','#c7d2fe'];
+
+const renderActiveShape = (props :any) => {
+  const RADIAN = Math.PI / 180;
+  const { cx, cy, midAngle, innerRadius, outerRadius, startAngle, endAngle, fill, payload, percent, value } = props;
+  const sin = Math.sin(-RADIAN * midAngle);
+  const cos = Math.cos(-RADIAN * midAngle);
+  const sx = cx + (outerRadius + 10) * cos;
+  const sy = cy + (outerRadius + 10) * sin;
+  const mx = cx + (outerRadius + 30) * cos;
+  const my = cy + (outerRadius + 30) * sin;
+  const ex = mx + (cos >= 0 ? 1 : -1) * 22;
+  const ey = my;
+  const textAnchor = cos >= 0 ? 'start' : 'end';
+
+  return (
+    <g>
+      <text x={cx} y={cy} dy={8} textAnchor="middle" fill="#333">
+        {payload.name}
+      </text>
+      <Sector
+        cx={cx}
+        cy={cy}
+        innerRadius={innerRadius}
+        outerRadius={outerRadius}
+        startAngle={startAngle}
+        endAngle={endAngle}
+        fill={fill}
+      />
+      <Sector
+        cx={cx}
+        cy={cy}
+        startAngle={startAngle}
+        endAngle={endAngle}
+        innerRadius={outerRadius + 6}
+        outerRadius={outerRadius + 10}
+        fill={fill}
+      />
+      <path d={`M${sx},${sy}L${mx},${my}L${ex},${ey}`} stroke={fill} fill="none" />
+      <circle cx={ex} cy={ey} r={2} fill={fill} stroke="none" />
+      <text x={ex + (cos >= 0 ? 1 : -1) * 12} y={ey} textAnchor={textAnchor} fill="#333">{`${value}客`}</text>
+      <text x={ex + (cos >= 0 ? 1 : -1) * 12} y={ey} dy={18} textAnchor={textAnchor} fill="#999">
+        {`(${(percent * 100).toFixed(1)}%)`}
+      </text>
+    </g>
+  );
+};
+
+export default function CustomersPie() {
+  useFetchCustomerRecords();
+
+  const [activeIndex, setActiveIndex] = useState(0);
+  const { options } = useCalculationStore();
+  const { customersRecord } = useDashboardStore();
+
+  const chartData = Object.entries(customersRecord).map(([id, count]) => {
+    const option = options.find(type => type.value.toString() === id);
+    const typeName = option ? option.label : '不明';
+  
+    return { name: typeName, value: count };
+  });
+
+  const onPieEnter = (_ :any, index :any) => {
+    setActiveIndex(index);
+  };
+
+  return (
+    <PieChart width={800} height={400}>
+      <Pie
+        activeIndex={activeIndex}
+        activeShape={renderActiveShape}
+        data={chartData}
+        cx={400}
+        cy={200}
+        innerRadius={60}
+        outerRadius={80}
+        fill="#8884d8"
+        dataKey="value"
+        onMouseEnter={onPieEnter}
+      >
+        {chartData.map((entry, index) => (
+          <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+        ))}
+      </Pie>
+    </PieChart>
+  );
+}

--- a/app/components/page/CustomerGraph/GraphArea.tsx
+++ b/app/components/page/CustomerGraph/GraphArea.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import CustomersPie from './CustomersPie'
+
+export default function GraphArea() {
+  return (
+    <div className="flex flex-row justify-center w-full max-w-lg pt-4 pb-7 md:py-7 bg-white rounded-md">
+      <CustomersPie/>
+    </div>
+  )
+}

--- a/app/components/page/DairyRecord/Caluculator.tsx
+++ b/app/components/page/DairyRecord/Caluculator.tsx
@@ -1,12 +1,12 @@
 "use client"
-import { useFetchResisterdDay } from '@/lib/useFetchData';
+import { useFetchForCalculator } from '@/lib/useFetchData';
 import { Fieldset } from '@mantine/core';
 import RecordInputForm from './RecordInputForm';
 import Datepicker from './DatePicker';
 
 export default function Caluculator() {
 
-  useFetchResisterdDay();
+  useFetchForCalculator();
 
   return (
     <>

--- a/app/components/page/DairyRecord/RecordInputForm.tsx
+++ b/app/components/page/DairyRecord/RecordInputForm.tsx
@@ -1,5 +1,4 @@
 "use client"
-import { useEffect } from 'react';
 import { z } from 'zod';
 import { useForm } from '@mantine/form';
 import { zodResolver } from 'mantine-form-zod-resolver';
@@ -20,7 +19,7 @@ const schema  = z.object({
 });
 
 export default function RecordInputForm () {
-  const { addToTotal, options, fetchOptions } = useCalculationStore();
+  const { addToTotal, options } = useCalculationStore();
 
   const form = useForm({
     initialValues: {
@@ -35,10 +34,6 @@ export default function RecordInputForm () {
     addToTotal(values);
     form.reset();
   };
-
-  useEffect(() => {
-    fetchOptions();
-  }, [fetchOptions]);
 
   return (
     <>

--- a/app/components/page/DairyRecord/Submit.tsx
+++ b/app/components/page/DairyRecord/Submit.tsx
@@ -1,6 +1,5 @@
 "use client"
 import { useRouter } from 'next/navigation'
-import { useSession } from 'next-auth/react';
 import axios from 'axios'
 import useCalculationStore from '@/store/calculationStore';
 import useDashboardStore from '@/store/dashboardStore';
@@ -14,8 +13,6 @@ import { Fieldset } from '@mantine/core';
 
 export default function Submit() {
   const router = useRouter()
-  const { data: session } = useSession();
-  const railsUserId = session?.user?.railsId;
   const { clearData, submitData } = useCalculationStore();
   const { fetchSalesRecord } = useDashboardStore((state) => ({fetchSalesRecord: state.fetchSalesRecord,}));
 
@@ -37,9 +34,7 @@ export default function Submit() {
 
       // response.dataから日付を取得
       const date = response.data.dairy_record.date;
-      if (railsUserId !== undefined) {
-        fetchSalesRecord(railsUserId, true);
-      }
+      fetchSalesRecord(true);
       router.push('/dashboard');
       showSuccessNotification(`${date}の売上を登録しました`);
       clearData();

--- a/app/components/page/DashBoard/ContentsLink.tsx
+++ b/app/components/page/DashBoard/ContentsLink.tsx
@@ -7,7 +7,7 @@ export default function ContentsLink() {
   return (
     <div className="flex flex-row justify-center items-center h-20 md:h-28 md:pb-3 md:mx-2 lg:mx-10">
       <div className="w-1/3 mx-2">
-        <div className='flex flex-col justify-center items-center text-gray-400 hover:text-sky-700 p-5 md:p-6 bg-white shadow-md rounded-md hover:shadow-lg hover:shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform cursor-pointer'>
+        <div className='flex flex-col justify-center items-center text-gray-400 hover:text-sky-700 p-5 md:p-6 bg-white shadow-md rounded-md hover:shadow-lg hover:shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform cursor-pointer' onClick={() => router.push('/customergraph')}>
           <ChartPieIcon className="w-8 h-8"/>
           <div className='text-xs text-gray-600 mt-1'>客層</div>
         </div>

--- a/app/components/page/DashBoard/NotJobRecord.tsx
+++ b/app/components/page/DashBoard/NotJobRecord.tsx
@@ -1,6 +1,5 @@
 "use client"
 import { useState } from 'react';
-import { useSession } from 'next-auth/react';
 import axios from 'axios'
 import useDashboardStore from '@/store/dashboardStore';
 import { formatDate } from '@/utils/dateUtils';
@@ -18,8 +17,6 @@ type  NotJobRecordProps = {
 export default function NotJobRecord({ selectedDate, close } :NotJobRecordProps) {
   const [ jobs, setJobs ] = useState<string[]>([]);
   const { jobsList } = useDashboardStore();
-  const { data: session } = useSession();
-  const railsUserId = session?.user?.railsId;
   const { fetchJobsRecord } = useDashboardStore((state) => ({fetchJobsRecord: state.fetchJobsRecord}));
 
   const handleSubmit = async () => {
@@ -32,9 +29,7 @@ export default function NotJobRecord({ selectedDate, close } :NotJobRecordProps)
           },
         });
         showSuccessNotification(`登録しました`);
-        if (railsUserId !== undefined) {
-          fetchJobsRecord(railsUserId, true);
-        }
+        fetchJobsRecord(true);
         close();
         setJobs([]);
       } catch (error) {

--- a/app/components/page/DashBoard/TargetInput.tsx
+++ b/app/components/page/DashBoard/TargetInput.tsx
@@ -1,5 +1,4 @@
 import axios from 'axios'
-import { useSession } from 'next-auth/react';
 import { getThisWeekRange, formatDateMD } from "@/utils/dateUtils";
 import { showSuccessNotification, showErrorNotification } from "@/utils/notifications";
 import useWeeklyStore from '@/store/weeklyStore';
@@ -13,8 +12,6 @@ type TargetInputProps = {
 };
 
 export default function TargetInput({close} :TargetInputProps) {
-  const { data: session } = useSession();
-  const railsUserId = session?.user?.railsId;
   const { target, clearData } = useWeeklyStore();
   const { fetchWeeklyTarget } = useDashboardStore((state) => ({fetchWeeklyTarget: state.fetchWeeklyTarget}));
   const { start, end } = getThisWeekRange();
@@ -31,9 +28,7 @@ export default function TargetInput({close} :TargetInputProps) {
           },
         });
         showSuccessNotification(`登録しました`);
-        if (railsUserId !== undefined) {
-          fetchWeeklyTarget(railsUserId, true);
-        }
+        fetchWeeklyTarget(true);
         close();
         clearData();
       } catch (error) {

--- a/app/components/page/StepForm/StepForm.tsx
+++ b/app/components/page/StepForm/StepForm.tsx
@@ -1,8 +1,7 @@
 "use client"
 import { useState } from 'react';
 import { useRouter } from 'next/navigation'
-import { useSession } from 'next-auth/react';
-import { useFetchData } from '@/lib/useFetchData';
+import { useFetchForWeekly } from '@/lib/useFetchData';
 import axios from 'axios'
 import useWeeklyStore from '@/store/weeklyStore';
 import useDashboardStore from '@/store/dashboardStore';
@@ -17,13 +16,11 @@ import SkipButton from '../../ui/button/SkipButton';
 import SubmitButton from '../../ui/button/SubmitButton';
 
 export default function StepForm() {
-  useFetchData();
+  useFetchForWeekly();
   const router = useRouter()
-  const { data: session } = useSession();
-  const railsUserId = session?.user?.railsId;
   const { target, setTarget, clearData, validateTarget, validateContent, getWeeklyReportData, getWeeklyTargetData } = useWeeklyStore();
   const { fetchWeeklyTarget } = useDashboardStore((state) => ({fetchWeeklyTarget: state.fetchWeeklyTarget}));
-
+  const { fetchWeeklyReport } = useDashboardStore((state) => ({fetchWeeklyReport: state.fetchWeeklyReport}));
   const [active, setActive] = useState(0);
 
   function validateContentStep() {
@@ -106,9 +103,9 @@ export default function StepForm() {
     } else {
       showSuccessNotification(`登録しました`);
     }
-    if (railsUserId !== undefined) {
-      fetchWeeklyTarget(railsUserId, true);
-    }
+
+    fetchWeeklyReport(true);
+    fetchWeeklyTarget(true);
     router.push('/dashboard');
     clearData();
   };

--- a/lib/useFetchData.ts
+++ b/lib/useFetchData.ts
@@ -2,6 +2,7 @@
 import { useSession } from 'next-auth/react';
 import { useEffect } from 'react';
 import useDashboardStore from '@/store/dashboardStore';
+import useCalculationStore from '@/store/calculationStore';
 
 export const useFetchData = () => {
   const { data: session } = useSession();
@@ -9,14 +10,16 @@ export const useFetchData = () => {
   const fetchSalesRecord = useDashboardStore((state) => state.fetchSalesRecord);
   const fetchWeeklyReport = useDashboardStore((state) => state.fetchWeeklyReport);
   const fetchWeeklyTarget = useDashboardStore((state) => state.fetchWeeklyTarget);
+  const fetchOptions = useCalculationStore((state) => state.fetchOptions);
 
   useEffect(() => {
     if (railsUserId) {
       fetchSalesRecord(railsUserId);
       fetchWeeklyReport(railsUserId);
       fetchWeeklyTarget(railsUserId);
+      fetchOptions();
     }
-  }, [railsUserId, fetchSalesRecord, fetchWeeklyTarget, fetchWeeklyReport]);
+  }, [railsUserId, fetchSalesRecord, fetchWeeklyTarget, fetchWeeklyReport,fetchOptions]);
 }
 
 export const useFetchResisterdDay = () => {
@@ -41,4 +44,16 @@ export const useFetchJobs = () => {
       fetchJobsRecord(railsUserId);
     }
   }, [railsUserId, fetchJobsRecord]);
+}
+
+export const useFetchCustomerRecords = () => {
+  const { data: session } = useSession();
+  const railsUserId = session?.user?.railsId;
+  const fetchCustomersRecord = useDashboardStore((state) => state.fetchCustomersRecord);
+  
+  useEffect(() => {
+    if (railsUserId) {
+      fetchCustomersRecord(railsUserId);
+    }
+  }, [railsUserId, fetchCustomersRecord])
 }

--- a/lib/useFetchData.ts
+++ b/lib/useFetchData.ts
@@ -1,59 +1,63 @@
 "use client"
-import { useSession } from 'next-auth/react';
 import { useEffect } from 'react';
 import useDashboardStore from '@/store/dashboardStore';
 import useCalculationStore from '@/store/calculationStore';
 
 export const useFetchData = () => {
-  const { data: session } = useSession();
-  const railsUserId = session?.user?.railsId;
   const fetchSalesRecord = useDashboardStore((state) => state.fetchSalesRecord);
   const fetchWeeklyReport = useDashboardStore((state) => state.fetchWeeklyReport);
   const fetchWeeklyTarget = useDashboardStore((state) => state.fetchWeeklyTarget);
   const fetchOptions = useCalculationStore((state) => state.fetchOptions);
-
+  const fetchCustomersRecord = useDashboardStore((state) => state.fetchCustomersRecord);
   useEffect(() => {
-    if (railsUserId) {
-      fetchSalesRecord(railsUserId);
-      fetchWeeklyReport(railsUserId);
-      fetchWeeklyTarget(railsUserId);
-      fetchOptions();
-    }
-  }, [railsUserId, fetchSalesRecord, fetchWeeklyTarget, fetchWeeklyReport,fetchOptions]);
+    fetchSalesRecord();
+    fetchWeeklyReport();
+    fetchWeeklyTarget();
+    fetchOptions();
+    fetchCustomersRecord();
+  }, [fetchSalesRecord, fetchWeeklyTarget, fetchWeeklyReport, fetchOptions, fetchCustomersRecord]);
 }
 
-export const useFetchResisterdDay = () => {
-  const { data: session } = useSession();
-  const railsUserId = session?.user?.railsId;
+export const useFetchForCalculator = () => {
   const fetchSalesRecord = useDashboardStore((state) => state.fetchSalesRecord);
-
+  const fetchOptions = useCalculationStore((state) => state.fetchOptions);
   useEffect(() => {
-    if (railsUserId) {
-      fetchSalesRecord(railsUserId);
-    }
-  }, [railsUserId, fetchSalesRecord]);
+    fetchSalesRecord();
+    fetchOptions();
+  }, [fetchSalesRecord,fetchOptions]);
 }
 
 export const useFetchJobs = () => {
-  const { data: session } = useSession();
-  const railsUserId = session?.user?.railsId;
   const fetchJobsRecord = useDashboardStore((state) => state.fetchJobsRecord);
-
   useEffect(() => {
-    if (railsUserId) {
-      fetchJobsRecord(railsUserId);
-    }
-  }, [railsUserId, fetchJobsRecord]);
+    console.log("useFetchJobs: fetching jobs record");
+    fetchJobsRecord();
+  }, [fetchJobsRecord]);
 }
 
-export const useFetchCustomerRecords = () => {
-  const { data: session } = useSession();
-  const railsUserId = session?.user?.railsId;
+export const useFetchForCustomersGraph = () => {
   const fetchCustomersRecord = useDashboardStore((state) => state.fetchCustomersRecord);
-  
+  const fetchOptions = useCalculationStore((state) => state.fetchOptions); 
   useEffect(() => {
-    if (railsUserId) {
-      fetchCustomersRecord(railsUserId);
-    }
-  }, [railsUserId, fetchCustomersRecord])
+    fetchOptions();
+    fetchCustomersRecord();
+  }, [fetchCustomersRecord, fetchOptions])
+}
+
+export const useFetchForArchive = () => {
+  const fetchSalesRecord = useDashboardStore((state) => state.fetchSalesRecord);
+  useEffect(() => {
+    fetchSalesRecord();
+  }, [fetchSalesRecord]);
+}
+
+export const useFetchForWeekly = () => {
+  const fetchSalesRecord = useDashboardStore((state) => state.fetchSalesRecord);
+  const fetchWeeklyReport = useDashboardStore((state) => state.fetchWeeklyReport);
+  const fetchWeeklyTarget = useDashboardStore((state) => state.fetchWeeklyTarget);
+  useEffect(() => {
+    fetchSalesRecord();
+    fetchWeeklyReport();
+    fetchWeeklyTarget();
+  }, [fetchSalesRecord, fetchWeeklyReport, fetchWeeklyTarget]);
 }

--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,7 @@ const nextConfig = {
         },
       ],
     },
+    // reactStrictMode: false,
   }
 
 module.exports = nextConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "next-auth": "^4.24.5",
         "react": "^18",
         "react-dom": "^18",
+        "recharts": "^2.10.3",
         "sharp": "^0.33.0",
         "zod": "^3.22.4",
         "zustand": "^4.4.7"
@@ -995,6 +996,60 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.2.tgz",
+      "integrity": "sha512-WAIEVlOCdd/NKRYTsqCpOMHQHemKBEINf8YXMYOtXH0GA7SY0dqMB78P3Uhgfy+4X+/Mlw2wDtlETkN6kQUCMA=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+      "integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+      "integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
+      "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -1790,6 +1845,116 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -1817,6 +1982,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2501,10 +2671,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-equals": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
+      "integrity": "sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
@@ -3031,6 +3214,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -3551,6 +3742,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -4347,6 +4543,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
     "node_modules/react-number-format": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.3.1.tgz",
@@ -4402,6 +4603,43 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-smooth": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-2.0.5.tgz",
+      "integrity": "sha512-BMP2Ad42tD60h0JW6BFaib+RJuV5dsXJK9Baxiv/HlNFjvRLqA9xrNKxVWnUIZPQfzUwGXIlU/dSYLU+54YGQA==",
+      "dependencies": {
+        "fast-equals": "^5.0.0",
+        "react-transition-group": "2.9.0"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.6.0",
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-smooth/node_modules/dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "dependencies": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
+    "node_modules/react-smooth/node_modules/react-transition-group": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+      "dependencies": {
+        "dom-helpers": "^3.4.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0",
+        "react-dom": ">=15.0.0"
       }
     },
     "node_modules/react-style-singleton": {
@@ -4476,6 +4714,37 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.10.3.tgz",
+      "integrity": "sha512-G4J96fKTZdfFQd6aQnZjo2nVNdXhp+uuLb00+cBTGLo85pChvm1+E67K3wBOHDE/77spcYb2Cy9gYWVqiZvQCg==",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.19",
+        "react-is": "^16.10.2",
+        "react-smooth": "^2.0.5",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.6.0",
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -5057,6 +5326,11 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
+      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5364,6 +5638,27 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.7.0",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.7.0.tgz",
+      "integrity": "sha512-nqYuTkLSdTTeACyXcCLbL7rl0y6jpzLPtTNGOtSnajdR+xxMxBdjMxDjfNJNlhR+ZU8vbXz+QejntcbY7h9/ZA==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "next-auth": "^4.24.5",
     "react": "^18",
     "react-dom": "^18",
+    "recharts": "^2.10.3",
     "sharp": "^0.33.0",
     "zod": "^3.22.4",
     "zustand": "^4.4.7"

--- a/store/calculationStore.ts
+++ b/store/calculationStore.ts
@@ -1,10 +1,6 @@
 import { create } from 'zustand';
 import { formatDate } from '@/utils/dateUtils';
-
-type Option = {
-  value: number;
-  label: string;
-};
+import { Option } from '@/types';
 
 type CustomerCounts = Record<string, number>;
 
@@ -21,7 +17,7 @@ type SubmitDataType = {
     count: number;
     date: string;
   };
-  customer_counts: Record<string, number>;
+  customer_counts: CustomerCounts;
 };
 
 type CalculationState = {
@@ -92,6 +88,7 @@ const useCalculationStore = create<CalculationState>((set, get) => ({
   },
 
   fetchOptions: async () => {
+    if (get().options.length === 0) {
     try {
       const response = await fetch(`/api/customer_types`);
 
@@ -103,7 +100,8 @@ const useCalculationStore = create<CalculationState>((set, get) => ({
     } catch (error) {
       console.error("Failed to fetch options", error);
     }
-  },
+  }
+},
 
   // customers配列を集計
   calculateCustomerCounts(customers: string[]): CustomerCounts {

--- a/store/dashboardStore.ts
+++ b/store/dashboardStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { SalesRecord, WeeklyTarget, WeeklyReport, ProgressData, ResisteredDateRange, JobRecord } from '@/types';
+import { SalesRecord, WeeklyTarget, WeeklyReport, ProgressData, ResisteredDateRange, JobRecord, CustomersRecord } from '@/types';
 import { getThisWeekRange } from '@/utils/dateUtils';
 import { calculateTotal, calculateSetRate, calculateAverage } from '@/utils/calculateUtils';
 
@@ -21,11 +21,13 @@ type DashboardState = {
   jobsRecords: JobRecord[];
   jobsDates: string[];
   jobsList: string[];
+  customersRecord: CustomersRecord;
   fetchSalesRecord: (userId: number, force?: boolean) => Promise<void>;
   fetchWeeklyReport: (userId: number, force?: boolean) => Promise<void>;
   fetchWeeklyTarget: (userId: number, force?: boolean) => Promise<void>;
   fetchJobsRecord: (userId: number, force?: boolean) => Promise<void>;
   getThisWeekProgress: () => ProgressData;
+  fetchCustomersRecord: (userId: number, force?: boolean) => Promise<void>;
 };
 
 const useDashboardStore = create<DashboardState>((set, get) => ({
@@ -46,6 +48,7 @@ const useDashboardStore = create<DashboardState>((set, get) => ({
   jobsRecords: [],
   jobsDates: [], 
   jobsList: [],
+  customersRecord: {},
   fetchSalesRecord: async (userId, force = false) => {
     if (force || get().lastFetchedUserId !== userId || get().salesRecords.length === 0) {
       try {
@@ -139,6 +142,19 @@ const useDashboardStore = create<DashboardState>((set, get) => ({
           jobsDates: dates, 
           lastFetchedUserId: userId,
           jobsList: jobs,
+        });
+      } catch (error) {
+        console.error("Failed to fetch", error);
+      }
+    }
+  },
+  fetchCustomersRecord: async (userId, force = false) => {
+    if (force || get().lastFetchedUserId !== userId || get().jobsRecords.length === 0) {
+      try {
+        const response = await fetch(`/api/customers`);
+        const data: CustomersRecord = await response.json();
+        set({
+          customersRecord: data
         });
       } catch (error) {
         console.error("Failed to fetch", error);

--- a/store/dashboardStore.ts
+++ b/store/dashboardStore.ts
@@ -4,7 +4,6 @@ import { getThisWeekRange } from '@/utils/dateUtils';
 import { calculateTotal, calculateSetRate, calculateAverage } from '@/utils/calculateUtils';
 
 type DashboardState = {
-  lastFetchedUserId: number | null;
   salesRecords: SalesRecord[];
   salesDates: string[];
   weeklyReports: WeeklyReport[];
@@ -22,16 +21,15 @@ type DashboardState = {
   jobsDates: string[];
   jobsList: string[];
   customersRecord: CustomersRecord;
-  fetchSalesRecord: (userId: number, force?: boolean) => Promise<void>;
-  fetchWeeklyReport: (userId: number, force?: boolean) => Promise<void>;
-  fetchWeeklyTarget: (userId: number, force?: boolean) => Promise<void>;
-  fetchJobsRecord: (userId: number, force?: boolean) => Promise<void>;
+  fetchSalesRecord: (force?: boolean) => Promise<void>;
+  fetchWeeklyReport: (force?: boolean) => Promise<void>;
+  fetchWeeklyTarget: (force?: boolean) => Promise<void>;
+  fetchJobsRecord: (force?: boolean) => Promise<void>;
   getThisWeekProgress: () => ProgressData;
-  fetchCustomersRecord: (userId: number, force?: boolean) => Promise<void>;
+  fetchCustomersRecord: (force?: boolean) => Promise<void>;
 };
 
 const useDashboardStore = create<DashboardState>((set, get) => ({
-  lastFetchedUserId: null,
   salesRecords: [],
   salesDates: [], // 売上記録の日付データ
   weeklyReports: [],
@@ -49,8 +47,8 @@ const useDashboardStore = create<DashboardState>((set, get) => ({
   jobsDates: [], 
   jobsList: [],
   customersRecord: {},
-  fetchSalesRecord: async (userId, force = false) => {
-    if (force || get().lastFetchedUserId !== userId || get().salesRecords.length === 0) {
+  fetchSalesRecord: async (force = false) => {
+    if (force || get().salesRecords.length === 0) {
       try {
         const response = await fetch(`/api/salesrecord`);
         const data: SalesRecord[] = await response.json();
@@ -67,7 +65,6 @@ const useDashboardStore = create<DashboardState>((set, get) => ({
         set({
           salesRecords: data, 
           salesDates: dates, 
-          lastFetchedUserId: userId,
           thisWeekRecord,
           thisWeekAmount,
           thisWeekNumber,
@@ -80,8 +77,8 @@ const useDashboardStore = create<DashboardState>((set, get) => ({
       }
     }
   },
-  fetchWeeklyTarget: async (userId, force = false) => {
-    if (force || get().lastFetchedUserId !== userId || get().weeklyTargets.length === 0) {
+  fetchWeeklyTarget: async (force = false) => {
+    if (force || get().weeklyTargets.length === 0) {
       try {
         const response = await fetch(`/api/weeklytarget`);
         const data: WeeklyTarget[] = await response.json();
@@ -97,7 +94,6 @@ const useDashboardStore = create<DashboardState>((set, get) => ({
       set({ 
         weeklyTargets: data, 
         registeredTargetRanges, 
-        lastFetchedUserId: userId,
         thisWeekTarget: thisWeekTarget ? thisWeekTarget.target : null
       });
       } catch (error) {
@@ -105,8 +101,8 @@ const useDashboardStore = create<DashboardState>((set, get) => ({
       }
     }
   },
-  fetchWeeklyReport: async (userId, force = false) => {
-    if (force || get().lastFetchedUserId !== userId || get().weeklyReports.length === 0) {
+  fetchWeeklyReport: async (force = false) => {
+    if (force || get().weeklyReports.length === 0) {
       try {
         const response = await fetch(`/api/weeklyreport`);
         const data: WeeklyReport[] = await response.json();
@@ -114,7 +110,7 @@ const useDashboardStore = create<DashboardState>((set, get) => ({
           startDate: report.start_date,
           endDate: report.end_date
         }));
-        set({ weeklyReports: data, registeredReportRanges, lastFetchedUserId: userId });
+        set({ weeklyReports: data, registeredReportRanges});
       } catch (error) {
         console.error("Failed to fetch", error);
       }
@@ -130,8 +126,9 @@ const useDashboardStore = create<DashboardState>((set, get) => ({
       progressPercent
     };
   },
-  fetchJobsRecord: async (userId, force = false) => {
-    if (force || get().lastFetchedUserId !== userId || get().jobsRecords.length === 0) {
+  fetchJobsRecord: async (force = false) => {
+    console.log("fetchJobsRecord called");
+    if (force || get().jobsRecords.length === 0) {
       try {
         const response = await fetch(`/api/jobrecord`);
         const data: JobRecord[] = await response.json();
@@ -140,7 +137,6 @@ const useDashboardStore = create<DashboardState>((set, get) => ({
         set({
           jobsRecords: data, 
           jobsDates: dates, 
-          lastFetchedUserId: userId,
           jobsList: jobs,
         });
       } catch (error) {
@@ -148,8 +144,8 @@ const useDashboardStore = create<DashboardState>((set, get) => ({
       }
     }
   },
-  fetchCustomersRecord: async (userId, force = false) => {
-    if (force || get().lastFetchedUserId !== userId || get().jobsRecords.length === 0) {
+  fetchCustomersRecord: async (force = false) => {
+    if (force || Object.keys(get().customersRecord).length === 0)  {
       try {
         const response = await fetch(`/api/customers`);
         const data: CustomersRecord = await response.json();

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,46 +1,51 @@
 export type SalesRecord = {
-    average_spend: number;
-    count: number;
-    date: string;
-    set_rate: number;
-    total_amount: number;
-    total_number: number;
+  average_spend: number;
+  count: number;
+  date: string;
+  set_rate: number;
+  total_amount: number;
+  total_number: number;
 };
 
 export type WeeklyTarget = {
-    target: number;
-    start_date: string;
-    end_date: string;
+  target: number;
+  start_date: string;
+  end_date: string;
 };
 
 export type WeeklyReport = {
-    content: string;
-    start_date: string;
-    end_date: string;
+  content: string;
+  start_date: string;
+  end_date: string;
 };
 
 export type WeeklyRecord = {
-    amount: number;
-    number: number;
-    count: number;
-    setRate: number;
-    average: number;
-    weekEnd: string;
+  amount: number;
+  number: number;
+  count: number;
+  setRate: number;
+  average: number;
+  weekEnd: string;
 };
 
 export type ResisteredDateRange = {
-    startDate: string;
-    endDate: string;
+  startDate: string;
+  endDate: string;
 };
 
 export type ProgressData = {
-    progress: number;
-    progressPercent: number;
+  progress: number;
+  progressPercent: number;
 };
 
 export type JobRecord = {
-    job: string;
-    date: string;
+  job: string;
+  date: string;
 };
 
 export type CustomersRecord = Record<number, number>;
+
+export type Option = {
+  value: number;
+  label: string;
+};

--- a/types/index.ts
+++ b/types/index.ts
@@ -42,3 +42,5 @@ export type JobRecord = {
     job: string;
     date: string;
 };
+
+export type CustomersRecord = Record<number, number>;


### PR DESCRIPTION
## 概要

バックエンドから客層の集計データを受け取りグラフ表示用のデータに生成。
生成データを使いPieチャートが表示される状態まで。

issue: #50  

その他：
グラフ表示の際に必要なデータを取得するため、各データのfetchタイミングを見直し。

## 変更点

- Recharts導入 
- 客層集計データを取得するfetch関数を作成し, APIルートを介してデータ取得

- fetch関数の条件修正（最後に取得したuserは不要なため条件から削除） 
- useFetchカスタムフックを各ページ必要最低限にして不要なサーバー通信をなくす


## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0

- バックエンドからデータを受け取りPieチャートで表示できるのを確認

## 影響範囲

- /dashboard
- /weekly
- /archive
- /dairyrecord
- /customergraph

## チェックリスト

- [x] Lintチェックをパスした