### PR TITLE
🐛 : スマホサイズでグラフが表示されない問題を修正 #51

### DIFF
--- a/app/(authenticated)/customergraph/page.tsx
+++ b/app/(authenticated)/customergraph/page.tsx
@@ -16,7 +16,7 @@ export default function page() {
         </div>
 
         <div className="flex flex-col sm:flex-row w-full max-w-lg pb-2 bg-white rounded-b-md shadow-b-sm">
-          <div className='md:w-3/4 md:pl-8 mx-auto'>
+          <div className='md:w-3/4 md:pl-8 ml-6 mr-5 md:ml-0 md:mr-0'>
             <CustomersPie colors={pieColors}/>
           </div>
           <div className='md:w-1/4 mx-auto  pl-2 mb-5'>


### PR DESCRIPTION
## 概要

グラフ表示のbug修正

issue: #51  

## 変更点

- md以下のマージンを調整（mx-auto削除しmr, mlで指定）

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0

- 375pxでリロードしても表示されていることを確認

## 影響範囲
- /customergraph

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応