### PR TITLE
Report Archive #48

### DIFF
--- a/app/(authenticated)/report/page.tsx
+++ b/app/(authenticated)/report/page.tsx
@@ -1,0 +1,13 @@
+import ReportArchive from "@/app/components/page/Report/ReportArchive"
+import Breadcrumbs from "@/app/components/ui/Breadcrumbs"
+
+export default function page() {
+  return (
+    <>
+      <Breadcrumbs>report</Breadcrumbs>
+      <div className="flex flex-col justify-center items-center mx-auto px-6 z-0 max-w-4xl mb-7 mt-4">
+        <ReportArchive/>
+      </div>
+    </>
+  )
+}

--- a/app/components/page/Archive/MonthlyArchive.tsx
+++ b/app/components/page/Archive/MonthlyArchive.tsx
@@ -5,9 +5,10 @@ import { formatDateYM } from "@/utils/dateUtils";
 import { calculateTotal, calculateSetRate, calculateAverage } from "@/utils/calculateUtils";
 import useDashboardStore from "@/store/dashboardStore";
 import MonthlyRecord from "./MonthlyRecord";
-import WeeklyArchive from "./WeeklyArchive";
+import RecordList from "./RecordList";
 import MonthPicker from "../../ui/MonthPicker";
 import { TriangleIcon } from "../../ui/icon/Triangle";
+
 
 export default function MonthlyArchive() {
 
@@ -54,7 +55,7 @@ export default function MonthlyArchive() {
         <div className='text-sm text-gray-800'>各週のデータ</div>
       </div>
 
-      <WeeklyArchive monthRecords={filteredSalesRecords} />
+      <RecordList monthRecords={filteredSalesRecords} />
     </div>    
     </>
   )

--- a/app/components/page/Archive/RecordContents.tsx
+++ b/app/components/page/Archive/RecordContents.tsx
@@ -11,7 +11,7 @@ type WeeklyRecordContents = {
   average: number;
 }
 
-export default function WeeklyRecordContents({ amount, number, count, setRate, average}: WeeklyRecordContents) {
+export default function RecordContents({ amount, number, count, setRate, average}: WeeklyRecordContents) {
   return (
     <div className="p-2">
       <div className="flex items-center text-gray-700">

--- a/app/components/page/Archive/RecordList.tsx
+++ b/app/components/page/Archive/RecordList.tsx
@@ -3,13 +3,13 @@ import { getWeekHead, getweekEndDate, sortData, formatDateLayoutMD } from "@/uti
 import { calculateSetRate, calculateAverage } from "@/utils/calculateUtils";
 import { Accordion } from '@mantine/core';
 import { ClipboardDocumentListIcon } from "@heroicons/react/24/outline";
-import WeeklyRecordContents from "./WeeklyRecordContents";
+import RecordContents from "./RecordContents";
 
 type WeeklyRecordProps = {
   monthRecords: SalesRecord[];
 };
 
-export default function WeeklyArchive({monthRecords} :WeeklyRecordProps) {
+export default function RecordList({monthRecords} :WeeklyRecordProps) {
 
   const weeklyData = monthRecords.reduce<Record<string, WeeklyRecord>>((acc, record) => {
     const weekHead = getWeekHead(record.date);
@@ -35,26 +35,28 @@ export default function WeeklyArchive({monthRecords} :WeeklyRecordProps) {
     <>
       <div className="px-7 md:px-12">
         <Accordion variant="contained">
-          {sortedWeeklyData.map(weekKey => (
-            
-            <Accordion.Item key={weekKey} value={weekKey}>
-              <Accordion.Control
-                icon={ <ClipboardDocumentListIcon className="w-6 h-6 ml-2 text-blue-300"/>
-                }
-              >
-                {formatDateLayoutMD(weekKey)} 〜 {formatDateLayoutMD(weeklyData[weekKey].weekEnd)}
-              </Accordion.Control>
-              <Accordion.Panel>
-                <WeeklyRecordContents 
-                  amount={weeklyData[weekKey].amount} 
-                  number={weeklyData[weekKey].number}
-                  count={weeklyData[weekKey].count}
-                  setRate={weeklyData[weekKey].setRate}
-                  average={weeklyData[weekKey].average}
-                  />
-              </Accordion.Panel>
-            </Accordion.Item>
-          ))}
+          {sortedWeeklyData.length > 0 ? (
+            sortedWeeklyData.map(weekKey => (
+              <Accordion.Item key={weekKey} value={weekKey}>
+                <Accordion.Control
+                  icon={ <ClipboardDocumentListIcon className="w-6 h-6 ml-2 text-blue-300"/>}
+                >
+                  {formatDateLayoutMD(weekKey)} 〜 {formatDateLayoutMD(weeklyData[weekKey].weekEnd)}
+                </Accordion.Control>
+                <Accordion.Panel>
+                  <RecordContents 
+                    amount={weeklyData[weekKey].amount} 
+                    number={weeklyData[weekKey].number}
+                    count={weeklyData[weekKey].count}
+                    setRate={weeklyData[weekKey].setRate}
+                    average={weeklyData[weekKey].average}
+                    />
+                </Accordion.Panel>
+              </Accordion.Item>
+            ))
+          ) : (
+            <div className="text-center text-gray-500 py-5">売上が登録されていません</div>
+          )}
         </Accordion>
       </div>
     </>

--- a/app/components/page/DashBoard/ContentsLink.tsx
+++ b/app/components/page/DashBoard/ContentsLink.tsx
@@ -19,7 +19,7 @@ export default function ContentsLink() {
         </div>
       </div>
       <div className="w-1/3 mx-2">
-        <div className='flex flex-col justify-center items-center text-gray-400 hover:text-sky-700 p-5 md:p-6 bg-white shadow-md rounded-md hover:shadow-lg hover:shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform cursor-pointer'>
+        <div className='flex flex-col justify-center items-center text-gray-400 hover:text-sky-700 p-5 md:p-6 bg-white shadow-md rounded-md hover:shadow-lg hover:shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform cursor-pointer' onClick={() => router.push('/report')}>
           <BookOpenIcon className="w-8 h-8" />
           <div className='text-xs text-gray-600 mt-1'>レポート</div>
         </div>

--- a/app/components/page/Report/CreateInfo.tsx
+++ b/app/components/page/Report/CreateInfo.tsx
@@ -1,0 +1,15 @@
+import { PaperAirplaneIcon } from '@heroicons/react/24/outline';
+import { Button } from '@mantine/core';
+
+export default function CreateInfo() {
+  return (
+    <>
+      <div className="flex flex-row justify-center items-center px-7 md:px-12">
+        <Button variant="filled" color="#60a5fa">
+          Create
+          <PaperAirplaneIcon className='w-5 h-5 ml-2'/>
+        </Button>
+      </div>
+    </>
+  )
+}

--- a/app/components/page/Report/ReportArchive.tsx
+++ b/app/components/page/Report/ReportArchive.tsx
@@ -1,14 +1,18 @@
 "use client"
 import { useState } from "react";
+import { useRouter } from 'next/navigation'
 import { formatDateYM } from "@/utils/dateUtils";
 import { useFetchForReport } from "@/lib/useFetchData";
 import useDashboardStore from "@/store/dashboardStore";
 import { TriangleIcon } from "../../ui/icon/Triangle"
 import MonthPicker from "../../ui/MonthPicker"
 import ReportList from "./ReportList";
+import CreateInfo from "./CreateInfo";
+import { ArrowRightCircleIcon } from "@heroicons/react/24/outline";
 
 export default function ReportArchive() {
   useFetchForReport();
+  const router = useRouter();
 
   const { weeklyReports } = useDashboardStore();
   const [value, setValue] = useState<Date | null>(new Date());
@@ -24,23 +28,37 @@ export default function ReportArchive() {
   return (
     <div className="flex flex-col justify-center w-full max-w-lg pt-4 pb-7 md:py-7 bg-white rounded-md">
 
-    <div className="flex flex-row justify-start px-7 pt-2 md:px-12">
-      <TriangleIcon className="w-4 h-4 mr-1 ml-4 text-blue-300" />
-      <div className='text-sm text-gray-800'>月を選択</div>
-    </div>
-
-    <div className="flex flex-col w-full justify-center items-center px-5 md:px-12"> 
-      <div className="w-full items-center max-w-md px-3 py-2">
-        <MonthPicker value={value} setValue={setValue} />
+      <div className='flex justify-end pr-5 pb-2'>
+        <div className='flex flex-row text-gray-600 text-sm items-center underline hover:text-sky-800 cursor-pointer' onClick={() => router.push('/weekly')}>
+          <div>週間レポートの登録はこちら</div>
+          <ArrowRightCircleIcon className="w-4 h-4 mr-1" />
+        </div>
       </div>
-    </div>
 
-    <div className="flex flex-row justify-start px-7 pt-5 pb-2 md:px-12">
-      <TriangleIcon className="w-4 h-4 mr-1 ml-4 text-blue-300" />
-      <div className='text-sm text-gray-800'>各週のデータ</div>
-    </div>
+      <div className="flex flex-row justify-start px-7 pt-2 md:px-12">
+        <TriangleIcon className="w-4 h-4 mr-1 ml-4 text-blue-300" />
+        <div className='text-sm text-gray-800'>月を選択</div>
+      </div>
 
-    <ReportList reportsList={filteredWeeklyReports} />
-  </div>  
+      <div className="flex flex-col w-full justify-center items-center px-5 md:px-12"> 
+        <div className="w-full items-center max-w-md px-3 py-2">
+          <MonthPicker value={value} setValue={setValue} />
+        </div>
+      </div>
+
+      <div className="flex flex-row justify-start px-7 pt-5 pb-2 md:px-12">
+        <TriangleIcon className="w-4 h-4 mr-1 ml-4 text-blue-300" />
+        <div className='text-sm text-gray-800'>各週のデータ</div>
+      </div>
+
+      <ReportList reportsList={filteredWeeklyReports} />
+
+      <div className="flex flex-row justify-start px-7 pt-6 pb-4 md:px-12">
+        <TriangleIcon className="w-4 h-4 mr-1 ml-4 text-blue-300" />
+        <div className='text-sm text-gray-800'>月間レポートを作成しますか？</div>
+      </div>
+
+      <CreateInfo />
+    </div>  
   )
 }

--- a/app/components/page/Report/ReportArchive.tsx
+++ b/app/components/page/Report/ReportArchive.tsx
@@ -1,0 +1,46 @@
+"use client"
+import { useState } from "react";
+import { formatDateYM } from "@/utils/dateUtils";
+import { useFetchForReport } from "@/lib/useFetchData";
+import useDashboardStore from "@/store/dashboardStore";
+import { TriangleIcon } from "../../ui/icon/Triangle"
+import MonthPicker from "../../ui/MonthPicker"
+import ReportList from "./ReportList";
+
+export default function ReportArchive() {
+  useFetchForReport();
+
+  const { weeklyReports } = useDashboardStore();
+  const [value, setValue] = useState<Date | null>(new Date());
+
+  const targetMonth = formatDateYM(value);
+
+
+  const filteredWeeklyReports = weeklyReports.filter(report => {
+    const reportMonth = report.start_date.substring(0, 7); 
+    return reportMonth === targetMonth;
+  });
+
+  return (
+    <div className="flex flex-col justify-center w-full max-w-lg pt-4 pb-7 md:py-7 bg-white rounded-md">
+
+    <div className="flex flex-row justify-start px-7 pt-2 md:px-12">
+      <TriangleIcon className="w-4 h-4 mr-1 ml-4 text-blue-300" />
+      <div className='text-sm text-gray-800'>月を選択</div>
+    </div>
+
+    <div className="flex flex-col w-full justify-center items-center px-5 md:px-12"> 
+      <div className="w-full items-center max-w-md px-3 py-2">
+        <MonthPicker value={value} setValue={setValue} />
+      </div>
+    </div>
+
+    <div className="flex flex-row justify-start px-7 pt-5 pb-2 md:px-12">
+      <TriangleIcon className="w-4 h-4 mr-1 ml-4 text-blue-300" />
+      <div className='text-sm text-gray-800'>各週のデータ</div>
+    </div>
+
+    <ReportList reportsList={filteredWeeklyReports} />
+  </div>  
+  )
+}

--- a/app/components/page/Report/ReportContent.tsx
+++ b/app/components/page/Report/ReportContent.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import CopyActionButton from '../../ui/CopyActionButton';
+
+type ReportContentProps = {
+  content: string;
+  }
+
+export default function ReportContent({content} : ReportContentProps) {
+  return (
+    <>
+      <div className='flex justify-end pr-2 pb-2'>
+        <CopyActionButton value={content}/>
+      </div>
+      <div className="p-4 bg-white rounded-sm">
+        <div className='text-sm md:text-md'>{content}</div>
+      </div>
+    </>
+  )
+}

--- a/app/components/page/Report/ReportList.tsx
+++ b/app/components/page/Report/ReportList.tsx
@@ -1,0 +1,36 @@
+import { WeeklyReport } from '@/types';
+import { formatDateLayoutMD } from '@/utils/dateUtils';
+import { Accordion } from '@mantine/core';
+import { ChatBubbleBottomCenterTextIcon } from "@heroicons/react/24/outline";
+import ReportContent from './ReportContent';
+
+type WeeklyRecordProps = {
+  reportsList: WeeklyReport[];
+};
+
+export default function ReportList({reportsList}: WeeklyRecordProps) {
+  return (
+    <>
+      <div className="px-7 md:px-14">
+        <Accordion variant="contained">
+          {reportsList.length > 0 ? (
+            reportsList.map((report, index) => (
+              <Accordion.Item key={index} value={report.start_date}>
+                <Accordion.Control
+                  icon={<ChatBubbleBottomCenterTextIcon className="w-6 h-6 ml-2 text-blue-300"/>}
+                >
+                  {formatDateLayoutMD(report.start_date)} 〜 {formatDateLayoutMD(report.end_date)}
+                </Accordion.Control>
+                <Accordion.Panel>
+                  <ReportContent content={report.content}/>
+                </Accordion.Panel>
+              </Accordion.Item>
+            ))
+          ) : (
+            <div className="text-center text-gray-500 py-5">レポートが登録されていません</div>
+          )}
+        </Accordion>
+      </div>
+    </>
+  )
+}

--- a/app/components/ui/CopyActionButton.tsx
+++ b/app/components/ui/CopyActionButton.tsx
@@ -1,0 +1,25 @@
+"use client"
+import { CopyButton, ActionIcon, Tooltip} from '@mantine/core';
+import { DocumentDuplicateIcon, CheckIcon } from "@heroicons/react/24/outline";
+
+type CopyProps = {
+  value: string;
+}
+
+export default function CopyActionButton({value}: CopyProps) {
+  return (
+    <CopyButton value={value} timeout={2000}>
+      {({ copied, copy }) => (
+        <Tooltip label={copied ? 'Copied' : 'Copy'} withArrow position="right">
+          <ActionIcon color={copied ? 'teal' : 'gray'} variant="subtle" onClick={copy}>
+            {copied ? (
+              <CheckIcon className='w-6 h-6' />
+            ) : (
+              <DocumentDuplicateIcon className='w-6 h-6' />
+            )}
+          </ActionIcon>
+        </Tooltip>
+      )}
+    </CopyButton>
+  );
+}

--- a/lib/useFetchData.ts
+++ b/lib/useFetchData.ts
@@ -62,3 +62,10 @@ export const useFetchForWeekly = () => {
     fetchWeeklyTarget();
   }, [fetchSalesRecord, fetchWeeklyReport, fetchWeeklyTarget]);
 }
+
+export const useFetchForReport = () => {
+  const fetchWeeklyReport = useDashboardStore((state) => state.fetchWeeklyReport);
+  useEffect(() => {
+    fetchWeeklyReport();
+  }, [fetchWeeklyReport]);
+}


### PR DESCRIPTION
## 概要

週間レポートの一覧画面を作成
issue: #48 

その他：
月間実績ページの修正

## 変更点

- reportページを作成
- コピーボタンコンポーネントの作成
- 月間実績のない場合に表示される文言を追加
- ファイル名の変更（レポート一覧と統一）

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0

- レポートの一覧が月ごとに表示されることを確認

## 影響範囲


## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応