### PR TITLE
Help #64

### DIFF
--- a/app/(authenticated)/dairyrecord/page.tsx
+++ b/app/(authenticated)/dairyrecord/page.tsx
@@ -1,5 +1,6 @@
 import Caluculator from "@/app/components/page/DairyRecord/Caluculator";
 import Submit from "@/app/components/page/DairyRecord/Submit";
+import HelpMordal from "@/app/components/ui/HelpMordal";
 
 export default function DairyRecordPage() {
     return (

--- a/app/components/page/DairyRecord/Caluculator.tsx
+++ b/app/components/page/DairyRecord/Caluculator.tsx
@@ -1,26 +1,64 @@
 "use client"
 import { useFetchForCalculator } from '@/lib/useFetchData';
-import { Fieldset } from '@mantine/core';
+import { Tabs } from '@mantine/core';
+import { TriangleIcon } from '../../ui/icon/Triangle';
+import HelpMordal from '../../ui/HelpMordal';
 import RecordInputForm from './RecordInputForm';
 import Datepicker from './DatePicker';
+import HelpPage from './HelpPage';
 
 export default function Caluculator() {
-
   useFetchForCalculator();
 
   return (
     <>
-    <div className="flex flex-col w-full max-w-lg">
-      <Fieldset legend="日付を選択" className='flex w-full'>
-        <div className="felx space-y-4 w-full px-2 mx-auto">
-          <Datepicker/>
-        </div>
-      </Fieldset>
-      <Fieldset legend="レシートから値を入力" className='w-full mt-3'>
-        <div className="flex space-y-4 w-full">
-          <RecordInputForm/>
-        </div>
-      </Fieldset>
+      <div className="flex flex-col w-full max-w-lg">
+        <Tabs variant="outline" defaultValue="sales">
+          <Tabs.List>
+            <div className="bg-white text-gray-500 rounded-sm">
+              <Tabs.Tab value="sales" leftSection={<TriangleIcon className="w-3 h-3 ml-2 text-blue-300"/>}>
+                <div className='flex flex-row mt-1 mr-2'>
+                  <div className="text-xs mr-1">STEP1.</div>
+                  <div className="text-xs text-gray-800">日付を選択</div>
+                </div>
+              </Tabs.Tab>
+            </div>
+            <div className="bg-white text-gray-500"></div>
+          </Tabs.List>
+          <Tabs.Panel value="sales">
+            <div className="bg-white px-7 pb-3 shadow-md rounded-b-sm border-x flex flex-col">
+              <div className="w-full px-3 pb-2 pt-4">
+                <Datepicker/>
+              </div>
+            </div>
+          </Tabs.Panel>
+        </Tabs>
+
+        <Tabs variant="outline" defaultValue="sales" className='pt-3 md:pt-6'>
+          <Tabs.List>
+            <div className="bg-white text-gray-500 rounded-sm">
+              <Tabs.Tab value="sales" leftSection={<TriangleIcon className="w-3 h-3 ml-2 text-blue-300"/>}>
+                <div className='flex flex-row mt-1 mr-2'>
+                  <div className="text-xs mr-1">STEP2.</div>
+                  <div className="text-xs text-gray-800">レシートから各値を入力</div>
+                </div>
+              </Tabs.Tab>
+            </div>
+            <div className="bg-white text-gray-500"></div>
+            <div className="flex justify-end mt-1 ml-3">
+                <HelpMordal>
+                  <HelpPage />
+                </HelpMordal>
+              </div>
+          </Tabs.List>
+          <Tabs.Panel value="sales">
+            <div className="bg-white px-7 shadow-md rounded-b-sm border-x flex flex-col">
+              <div className="flex pt-1 pb-5 w-full px-2">
+                <RecordInputForm/>
+              </div>
+            </div>
+          </Tabs.Panel>
+        </Tabs>
       </div>
     </>
   )

--- a/app/components/page/DairyRecord/CurrentData.tsx
+++ b/app/components/page/DairyRecord/CurrentData.tsx
@@ -9,14 +9,14 @@ export default function CurrentData() {
   
   return (
     <>
-      <div className="flex flex-row justify-center w-full overflow-auto">
-        <div className="flex flex-col justify-center py-2 px-6 lg:px-8">
+      <div className="flex flex-row justify-center w-full">
+        <div className="flex flex-col justify-center py-2 px-6 lg:px-8 w-1/3">
           <UserIcon className="w-8 h-8 mx-auto text-gray-500"/>
           <p className="text-xs mx-auto text-gray-400">
             客数
           </p>
           <div className="flex flex-row items-center justify-center whitespace-nowrap mt-2 h-10">
-            <h2 className="title-font font-medium text-lg md:text-xl text-gray-600 mr-1">
+            <h2 className="title-font font-medium text-md md:text-xl text-gray-600 mr-1">
               {count}
             </h2>
             <div className="md:hidden">
@@ -24,24 +24,24 @@ export default function CurrentData() {
             </div>
           </div>
         </div>
-        <div className="flex flex-col justify-center py-2 px-6 lg:px-8 border-l border-gray-200">
+        <div className="flex flex-col justify-center py-2 px-6 lg:px-8 border-l border-gray-200 w-1/3">
           <ShirtIcon className="w-8 h-8 mx-auto text-gray-500"/>
           <p className="flex text-xs mx-auto text-gray-400">
             点数
           </p>
           <div className="flex flex-row items-center justify-center whitespace-nowrap mt-2 h-10">
-            <h2 className="title-font font-medium text-lg md:text-xl text-gray-600">
+            <h2 className="title-font font-medium text-md md:text-xl text-gray-600">
               {totalNumber}
             </h2>
           </div>
         </div>
-        <div className="flex flex-col justify-center py-2 px-6 lg:px-8 border-l border-gray-200">
+        <div className="flex flex-col justify-center py-2 px-6 ml-2 lg:px-8 border-l border-gray-200 w-1/3">
           <CurrencyYenIcon className="w-8 h-8 mx-auto text-gray-500"/>
           <p className="flex text-xs mx-auto text-gray-400">
             金額
           </p>
           <div className="flex flex-row items-center justify-center whitespace-nowrap mt-2 h-10">
-            <h2 className="title-font font-medium text-lg md:text-xl text-gray-600">
+            <h2 className="title-font font-medium text-md md:text-xl text-gray-600 ml-2">
               {formatCurrency(totalAmount)}
             </h2>
           </div>

--- a/app/components/page/DairyRecord/HelpPage.tsx
+++ b/app/components/page/DairyRecord/HelpPage.tsx
@@ -1,0 +1,41 @@
+import { CheckBadgeIcon } from "@heroicons/react/24/outline"
+
+export default function HelpPage() {
+  return (
+    <>
+      <div className="p-2">
+        <div className="flex items-center text-gray-700 underline">
+          <CheckBadgeIcon className="w-6 h-6 text-blue-300 mr-2 font-bold" />
+          入力エリア
+        </div>
+        <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
+          レシートごとに、フォームに沿って各値を入力してください。すべて入力必須です。
+        </div>
+
+        <div className="flex items-center text-gray-700 border-t underline pt-2">
+          <CheckBadgeIcon className="w-6 h-6 text-blue-300 mr-2 font-bold" />
+          加算するボタン
+        </div>
+        <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
+          ボタンを押すと現在の合計値に入力値が加算されます。入力→加算ボタンをレシート分繰り返してください。
+        </div>
+
+        <div className="flex items-center text-gray-700 border-t underline pt-2">
+          <CheckBadgeIcon className="w-6 h-6 text-blue-300 mr-2 font-bold" />
+          登録ボタン
+        </div>
+        <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
+          日付, 現在の合計値を確認したら登録ボタンを押して売上データを登録！登録したデータはダッシュボードのカレンダーから確認できます。 
+        </div>
+
+        <div className="flex items-center text-gray-700 border-t underline pt-3">
+          <CheckBadgeIcon className="w-6 h-6 text-blue-300 mr-2 font-bold" />
+          クリアボタン
+        </div>
+        <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
+          現在の合計値がリセットされます。
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/components/page/DairyRecord/RecordInputForm.tsx
+++ b/app/components/page/DairyRecord/RecordInputForm.tsx
@@ -38,7 +38,7 @@ export default function RecordInputForm () {
   return (
     <>
       <div className="flex justify-center items-center w-full">
-        <form onSubmit={form.onSubmit(handleSubmit)} className='w-full mx-auto px-2'>
+        <form onSubmit={form.onSubmit(handleSubmit)} className='w-full'>
           <NumberInput
             {...form.getInputProps('number')}
             label="点数"
@@ -74,8 +74,8 @@ export default function RecordInputForm () {
             }))}
           />
 
-          <div className="flex justify-center mt-4">
-            <PlusButton size="sm" type="submit">加算する</PlusButton>
+          <div className="flex justify-end mt-4">
+            <PlusButton size="xs" type="submit">加算する</PlusButton>
           </div>
         </form>
       </div>

--- a/app/components/page/DairyRecord/Submit.tsx
+++ b/app/components/page/DairyRecord/Submit.tsx
@@ -9,7 +9,8 @@ import ClearButton from '../../ui/button/ClearButton';
 import SubmitButton from '../../ui/button/SubmitButton';
 import CurrentDate from './CurrentDate';
 import CustomersList from './CustomersList';
-import { Fieldset } from '@mantine/core';
+import { Tabs } from '@mantine/core';
+import { TriangleIcon } from '../../ui/icon/Triangle';
 
 export default function Submit() {
   const router = useRouter()
@@ -46,22 +47,35 @@ export default function Submit() {
 
   return (
     <>
-      <Fieldset legend="現在の合計" className='w-full mt-3 max-w-lg' style={{ overflowX: 'auto' }}>
-        <div className="flex flex-col space-y-4 w-full">
-          <CurrentDate/>
-          <CurrentData/>
-
-          {/* md以上のみ表示 */}
-          <div className="hidden md:block"> 
-            <CustomersList/>
+      <Tabs variant="outline" defaultValue="sales" className='w-full mt-3 max-w-lg'>
+        <Tabs.List>
+          <div className="bg-white text-gray-500 rounded-sm">
+            <Tabs.Tab value="sales" leftSection={<TriangleIcon className="w-3 h-3 ml-2 text-blue-300"/>}>
+              <div className='flex flex-row mt-1 mr-2'>
+                <div className="text-xs mr-1">STEP3.</div>
+                <div className="text-xs text-gray-800">現在の合計値</div>
+              </div>
+            </Tabs.Tab>
           </div>
-
-          <div className="flex justify-center mt-4 gap-4">
-            <ClearButton size="sm" onClick={clearData}/>
-            <SubmitButton size="sm" type="submit" onClick={handleSubmit}/>
+          <div className="bg-white text-gray-500"></div>
+        </Tabs.List>
+        <Tabs.Panel value="sales">
+          <div className="bg-white px-7 pb-3 shadow-md rounded-b-sm border-x flex flex-col">
+            <div className="flex flex-col px-2 pb-3 pt-5 space-y-5 w-full">
+              <CurrentDate/>
+              <CurrentData/>
+              {/* md以上のみ表示 */}
+              <div className="hidden md:block"> 
+                <CustomersList/>
+              </div>
+              <div className="flex justify-center mt-4 gap-4">
+                <ClearButton size="sm" onClick={clearData}/>
+                <SubmitButton size="sm" type="submit" onClick={handleSubmit}/>
+              </div>
+            </div>
           </div>
-        </div>
-      </Fieldset>
+        </Tabs.Panel>
+      </Tabs>
     </>
   )
 }

--- a/app/components/page/DashBoard/CalenderArea.tsx
+++ b/app/components/page/DashBoard/CalenderArea.tsx
@@ -3,6 +3,8 @@ import SalesCalender from "./SalesCalendar"
 import { Tabs } from '@mantine/core';
 import { TriangleIcon } from "../../ui/icon/Triangle";
 import JobsCalender from "./JobsCalendar";
+import HelpMordal from "../../ui/HelpMordal";
+import HelpPage from "./HelpPage";
 
 export default function CalenderArea() {
   return (
@@ -17,6 +19,11 @@ export default function CalenderArea() {
           <Tabs.Tab value="jobs" leftSection={<TriangleIcon className="w-3 h-3 text-yellow-200"/>}>
           <div className="text-xs p-1">業務記録</div>
           </Tabs.Tab>
+        </div>
+        <div className="mx-8 mt-1">
+          <HelpMordal>
+            <HelpPage />
+          </HelpMordal>
         </div>
       </Tabs.List>
 

--- a/app/components/page/DashBoard/HelpPage.tsx
+++ b/app/components/page/DashBoard/HelpPage.tsx
@@ -1,0 +1,36 @@
+import { CheckBadgeIcon } from "@heroicons/react/24/outline"
+
+export default function HelpPage() {
+  return (
+    <>
+      <div className="p-2">
+        <div className="flex items-center text-gray-700 underline pt-2">
+          <CheckBadgeIcon className="w-6 h-6 text-blue-300 mr-2 font-bold" />
+          週間進捗エリア
+        </div>
+        <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
+          <p>まずは今週の目標を登録。</p>
+          <p>目標達成できるように頑張りましょう！</p>
+        </div> 
+        
+        <div className="flex items-center text-gray-700 underline border-t pt-2">
+          <CheckBadgeIcon className="w-6 h-6 text-blue-300 mr-2 font-bold" />
+          売上記録カレンダー
+        </div>
+        <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
+          <p>日付を選択して記録した日の売上データを確認 or その日の売上データを記録できます。</p>
+          <p>記録する度にアプリ内の各コンテンツに反映されます。</p>
+        </div>
+
+        <div className="flex items-center text-gray-700 border-t underline pt-2">
+          <CheckBadgeIcon className="w-6 h-6 text-blue-300 mr-2 font-bold" />
+          業務記録カレンダー
+        </div>
+        <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
+          <p>日付を選択して記録した日の業務データを確認 or その日行った業務を記録できます。</p>
+          <p>一度入力した業務は記憶されるので２度目からはサクサク入力！</p>
+        </div>         
+      </div>
+    </>
+  )
+}

--- a/app/components/page/Report/CreateInfo.tsx
+++ b/app/components/page/Report/CreateInfo.tsx
@@ -1,13 +1,13 @@
-import { PaperAirplaneIcon } from '@heroicons/react/24/outline';
 import { Button } from '@mantine/core';
+import { PaperAirplaneIcon } from '@heroicons/react/24/outline';
 
 export default function CreateInfo() {
   return (
     <>
       <div className="flex flex-row justify-center items-center px-7 md:px-12">
-        <Button variant="filled" color="#60a5fa">
+        <Button variant="outline" color="#9ca3af" className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform" >
           Create
-          <PaperAirplaneIcon className='w-5 h-5 ml-2'/>
+          <PaperAirplaneIcon className="w-5 h-5 ml-1 text-blue-400" />
         </Button>
       </div>
     </>

--- a/app/components/page/Report/HelpPage.tsx
+++ b/app/components/page/Report/HelpPage.tsx
@@ -1,0 +1,26 @@
+import { CheckBadgeIcon } from "@heroicons/react/24/outline"
+
+export default function HelpPage() {
+  return (
+    <>
+      <div className="p-2">
+        <div className="flex items-center text-gray-700 underline">
+          <CheckBadgeIcon className="w-6 h-6 text-blue-300 mr-2 font-bold" />
+          週間レポート一覧
+        </div>
+        <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
+          <p>登録した過去の週間レポートを月ごとに表示します。</p>
+          <p>各レポートはコピーボタンでコピー可能です。</p>
+        </div>
+
+        <div className="flex items-center text-gray-700 underline border-t pt-2">
+          <CheckBadgeIcon className="w-6 h-6 text-blue-300 mr-2 font-bold" />
+          月間レポートの作成について
+        </div>
+        <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
+          <p>週間レポートを３週分以上登録したら, それを元に月間レポートを自動で作成します。</p>
+        </div>  
+      </div>
+    </>
+  )
+}

--- a/app/components/page/Report/ReportArchive.tsx
+++ b/app/components/page/Report/ReportArchive.tsx
@@ -9,6 +9,8 @@ import MonthPicker from "../../ui/MonthPicker"
 import ReportList from "./ReportList";
 import CreateInfo from "./CreateInfo";
 import { ArrowRightCircleIcon } from "@heroicons/react/24/outline";
+import HelpMordal from "../../ui/HelpMordal";
+import HelpPage from "./HelpPage";
 
 export default function ReportArchive() {
   useFetchForReport();
@@ -53,9 +55,12 @@ export default function ReportArchive() {
 
       <ReportList reportsList={filteredWeeklyReports} />
 
-      <div className="flex flex-row justify-start px-7 pt-6 pb-4 md:px-12">
+      <div className="flex flex-row justify-start px-7 pt-6 pb-4 md:px-12 items-center">
         <TriangleIcon className="w-4 h-4 mr-1 ml-4 text-blue-300" />
-        <div className='text-sm text-gray-800'>月間レポートを作成しますか？</div>
+        <div className='text-sm text-gray-800 mr-2'>月間レポートを作成しますか？</div>
+        <HelpMordal>
+          <HelpPage/>
+        </HelpMordal>
       </div>
 
       <CreateInfo />

--- a/app/components/page/StepForm/AchievementsDetail.tsx
+++ b/app/components/page/StepForm/AchievementsDetail.tsx
@@ -17,7 +17,7 @@ type AchievementsDetailProps = {
 export default function AchievementsDetail({amount, number, count, set, average, progressPercent, progress} :AchievementsDetailProps) {
 
   return (
-    <div className="p-4 border-t-8"> 
+    <div className="p-4 border-t-4"> 
       <div className="flex flex-row items-center text-gray-700">
         <FlagIcon className="w-6 h-6 text-sky-800 mr-2" />
         目標達成率

--- a/app/components/page/StepForm/HelpPage.tsx
+++ b/app/components/page/StepForm/HelpPage.tsx
@@ -10,7 +10,7 @@ export default function HelpPage() {
         </div>
         <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
           <p>今週の振り返りを入力しましょう。</p>
-          <p>⚠️ 実績は "今週のみ" 確認可能です。</p>
+          <p>⚠️ 実績は『今週のみ』確認可能です。</p>
           <p>⚠️ 先週以降の実績はダッシュボードより確認してください。</p>
         </div>
 

--- a/app/components/page/StepForm/HelpPage.tsx
+++ b/app/components/page/StepForm/HelpPage.tsx
@@ -1,0 +1,28 @@
+import { CheckBadgeIcon } from "@heroicons/react/24/outline"
+
+export default function HelpPage() {
+  return (
+    <>
+      <div className="p-2">
+        <div className="flex items-center text-gray-700 underline">
+          <CheckBadgeIcon className="w-6 h-6 text-blue-300 mr-2 font-bold" />
+          週間レポートの登録
+        </div>
+        <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
+          <p>今週の振り返りを入力しましょう。</p>
+          <p>⚠️ 実績は "今週のみ" 確認可能です。</p>
+          <p>⚠️ 先週以降の実績はダッシュボードより確認してください。</p>
+        </div>
+
+        <div className="flex items-center text-gray-700 underline border-t pt-2">
+          <CheckBadgeIcon className="w-6 h-6 text-blue-300 mr-2 font-bold" />
+          来週の目標設定
+        </div>
+        <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
+          <p>続けて入力できます。</p>
+          <p>あとで設定したい場合はスキップボタンを押してください。</p>
+        </div>  
+      </div>
+    </>
+  )
+}

--- a/app/components/page/StepForm/Report.tsx
+++ b/app/components/page/StepForm/Report.tsx
@@ -2,6 +2,8 @@ import ReportRangeInput from '../WeeklyReport.tsx/RepotRangeInput';
 import ReportInputForm from '../WeeklyReport.tsx/ReportInput';
 import { PencilIcon } from '@heroicons/react/24/outline';
 import Achievements from './Achievements';
+import HelpMordal from '../../ui/HelpMordal';
+import HelpPage from './HelpPage';
 
 export default function Report() {
   return (
@@ -9,10 +11,17 @@ export default function Report() {
 
       <div className="flex flex-row justify-center items-center w-full border-b pb-2 mb-2 md:hidden">
         <PencilIcon className="w-6 h-6 text-gray-500 mr-2"/>
-        <span className="mx-1 text-sm text-gray-700">今週の振り返りを入力</span>
+        <span className="mx-1 mb-1 text-sm text-gray-700">今週の振り返りを入力</span>
       </div>
       
-      <div className="flex space-y-3 w-full p-2 mx-auto">
+      <div className='flex justify-end'>
+        <HelpMordal>
+          <HelpPage/>
+        </HelpMordal>
+      </div>
+  
+      
+      <div className="flex space-y-3 w-full px-2 mx-auto">
         <ReportRangeInput />
       </div>
 

--- a/app/components/ui/HelpMordal.tsx
+++ b/app/components/ui/HelpMordal.tsx
@@ -5,6 +5,20 @@ import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
 
 export default function HelpMordal({children}: any) {
   const [opened, { open, close }] = useDisclosure(false);
+
+  const renderModalTitle = () => {
+      return (
+        <>
+          <div className='flex flex-row items-start w-full pt-4 pr-22 mr-16 mb-1 text-md font-bold text-gray-600'>
+            <div className='flex w-full mr-12 ml-2 items-center'>
+              <QuestionMarkCircleIcon  className="w-8 h-8 text-gray-500 mr-2" />
+              使い方
+            </div>
+          </div>
+        </>
+      );
+  };
+
   return (
     <>
       <ActionIcon
@@ -18,7 +32,7 @@ export default function HelpMordal({children}: any) {
       >
         <QuestionMarkCircleIcon className="w-7 h-7 text-gray-400 hover:text-sky-700"/>
       </ActionIcon>
-      <Modal opened={opened} onClose={close} centered size="auto">
+      <Modal opened={opened} onClose={close} title={renderModalTitle()} centered size="auto">
         {children}
       </Modal>
     </>

--- a/app/components/ui/HelpMordal.tsx
+++ b/app/components/ui/HelpMordal.tsx
@@ -1,0 +1,26 @@
+"use client"
+import { useDisclosure } from '@mantine/hooks';
+import { Modal, ActionIcon } from '@mantine/core';
+import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
+
+export default function HelpMordal({children}: any) {
+  const [opened, { open, close }] = useDisclosure(false);
+  return (
+    <>
+      <ActionIcon
+        variant="transparent"
+        size="md"
+        radius="lg"
+        color="#e2e8f0"
+        aria-label="Settings" 
+        className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform"
+        onClick={open}
+      >
+        <QuestionMarkCircleIcon className="w-7 h-7 text-gray-400 hover:text-sky-700"/>
+      </ActionIcon>
+      <Modal opened={opened} onClose={close} centered size="auto">
+        {children}
+      </Modal>
+    </>
+  )
+}


### PR DESCRIPTION
## 概要

各ページにヘルプページを作成

issue: #33 
issue: #34
issue: #64 

## 変更点

- ヘルプページ表示用のモーダルコンポーネントを作成
- 各ページに設置。

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0

各ページでヘルプページが表示されることを確認

## 影響範囲
- /dashboard
- /dairyrecord
- /weekly
- /report

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応