### PR TITLE
Setting #52

### DIFF
--- a/app/(authenticated)/setting/page.tsx
+++ b/app/(authenticated)/setting/page.tsx
@@ -1,0 +1,12 @@
+import Steps from '@/app/components/page/Setting/Steps'
+import React from 'react'
+
+export default function Setting() {
+  return (
+    <>
+      <div className="flex flex-col justify-center items-center mx-auto px-6 z-0 max-w-4xl mb-7 mt-4">
+        <Steps/>
+      </div>
+    </>
+  )
+}

--- a/app/components/base/DrawerMenu.tsx
+++ b/app/components/base/DrawerMenu.tsx
@@ -14,7 +14,7 @@ export default function DrawerMenu() {
   if(session)
     return (
       <>
-        <Drawer opened={opened} onClose={close} size="xs">
+        <Drawer opened={opened} onClose={close} size="sm">
           <DrawerContents active={active} setActive={setActive} onClose={close}/>
         </Drawer >
   

--- a/app/components/base/FooterMenu.tsx
+++ b/app/components/base/FooterMenu.tsx
@@ -75,11 +75,11 @@ export default function FooterMenu() {
         </div>
       </footer>
 
-      <Drawer opened={opened} onClose={close} size="50%" position="bottom" title={title()} zIndex={5}>
+      <Drawer opened={opened} onClose={close} size="40%" position="bottom" title={title()} zIndex={5}>
         <FooterDrawer active={active} setActive={setActive} onClose={close}/>
       </Drawer >
 
-      <Drawer opened={openedUser} onClose={closeUser} size="40%" position="bottom" title={titleUser()} zIndex={5}>
+      <Drawer opened={openedUser} onClose={closeUser} size="30%" position="bottom" title={titleUser()} zIndex={5}>
         <ProfileDrawer active={active} setActive={setActive} onClose={closeUser}/>
       </Drawer>
     </>

--- a/app/components/page/DairyRecord/Caluculator.tsx
+++ b/app/components/page/DairyRecord/Caluculator.tsx
@@ -16,14 +16,19 @@ export default function Caluculator() {
         <Tabs variant="outline" defaultValue="sales">
           <Tabs.List>
             <div className="bg-white text-gray-500 rounded-sm">
-              <Tabs.Tab value="sales" leftSection={<TriangleIcon className="w-3 h-3 ml-2 text-blue-300"/>}>
+              <Tabs.Tab value="sales" leftSection={<TriangleIcon className="w-4 h-4 ml-2 text-blue-300"/>}>
                 <div className='flex flex-row mt-1 mr-2'>
                   <div className="text-xs mr-1">STEP1.</div>
-                  <div className="text-xs text-gray-800">日付を選択</div>
+                  <div className="text-xs text-gray-800 mr-16">日付を選択</div>
                 </div>
               </Tabs.Tab>
             </div>
             <div className="bg-white text-gray-500"></div>
+            <div className="flex justify-end mt-1 ml-6">
+              <HelpMordal>
+                <HelpPage />
+              </HelpMordal>
+            </div>
           </Tabs.List>
           <Tabs.Panel value="sales">
             <div className="bg-white px-7 pb-3 shadow-md rounded-b-sm border-x flex flex-col">
@@ -33,32 +38,18 @@ export default function Caluculator() {
             </div>
           </Tabs.Panel>
         </Tabs>
-
-        <Tabs variant="outline" defaultValue="sales" className='pt-3 md:pt-6'>
-          <Tabs.List>
-            <div className="bg-white text-gray-500 rounded-sm">
-              <Tabs.Tab value="sales" leftSection={<TriangleIcon className="w-3 h-3 ml-2 text-blue-300"/>}>
-                <div className='flex flex-row mt-1 mr-2'>
-                  <div className="text-xs mr-1">STEP2.</div>
-                  <div className="text-xs text-gray-800">レシートから各値を入力</div>
-                </div>
-              </Tabs.Tab>
+        <div className="bg-white px-6 shadow-md rounded-sm flex flex-col pt-3 mt-3 md:mt-5 border">
+          <div className="flex flex-raw text-gray-500 items-center mb-2">
+            <TriangleIcon className="w-4 h-4 mr-2 text-blue-300"/>
+            <div className='flex flex-row mt-1 mr-2'>
+              <div className="text-xs mr-1">STEP2.</div>
+              <div className="text-xs text-gray-800">レシートから各値を入力</div>
             </div>
-            <div className="bg-white text-gray-500"></div>
-            <div className="flex justify-end mt-1 ml-3">
-                <HelpMordal>
-                  <HelpPage />
-                </HelpMordal>
-              </div>
-          </Tabs.List>
-          <Tabs.Panel value="sales">
-            <div className="bg-white px-7 shadow-md rounded-b-sm border-x flex flex-col">
-              <div className="flex pt-1 pb-5 w-full px-2">
-                <RecordInputForm/>
-              </div>
-            </div>
-          </Tabs.Panel>
-        </Tabs>
+          </div>
+          <div className="flex pt-1 pb-5 w-full px-2">
+            <RecordInputForm/>
+          </div>
+        </div>
       </div>
     </>
   )

--- a/app/components/page/DairyRecord/Submit.tsx
+++ b/app/components/page/DairyRecord/Submit.tsx
@@ -47,20 +47,15 @@ export default function Submit() {
 
   return (
     <>
-      <Tabs variant="outline" defaultValue="sales" className='w-full mt-3 max-w-lg'>
-        <Tabs.List>
-          <div className="bg-white text-gray-500 rounded-sm">
-            <Tabs.Tab value="sales" leftSection={<TriangleIcon className="w-3 h-3 ml-2 text-blue-300"/>}>
-              <div className='flex flex-row mt-1 mr-2'>
-                <div className="text-xs mr-1">STEP3.</div>
-                <div className="text-xs text-gray-800">現在の合計値</div>
-              </div>
-            </Tabs.Tab>
+      <div className='w-full mt-3 max-w-lg bg-white text-gray-500 rounded-sm border pt-3 md:mt-5 shadow-md'>
+        <div className="flex flex-row items-center px-6">
+          <TriangleIcon className="w-4 h-4 text-blue-300 mr-2"/>
+          <div className='flex flex-row mt-1 mr-2'>
+            <div className="text-xs mr-1">STEP3.</div>
+            <div className="text-xs text-gray-800 mr-16">現在の合計値</div>
           </div>
-          <div className="bg-white text-gray-500"></div>
-        </Tabs.List>
-        <Tabs.Panel value="sales">
-          <div className="bg-white px-7 pb-3 shadow-md rounded-b-sm border-x flex flex-col">
+        </div>
+          <div className="bg-white px-7 pb-3 flex flex-col">
             <div className="flex flex-col px-2 pb-3 pt-5 space-y-5 w-full">
               <CurrentDate/>
               <CurrentData/>
@@ -74,8 +69,7 @@ export default function Submit() {
               </div>
             </div>
           </div>
-        </Tabs.Panel>
-      </Tabs>
+      </div>
     </>
   )
 }

--- a/app/components/page/Setting/AlertSelect.tsx
+++ b/app/components/page/Setting/AlertSelect.tsx
@@ -1,0 +1,41 @@
+"use client"
+import { useState } from 'react';
+import { Radio, Group, Button} from '@mantine/core';
+import { TriangleIcon } from '../../ui/icon/Triangle';
+import { ArrowPathIcon } from "@heroicons/react/24/outline";
+
+export default function AlertSelect() {
+  const [checked, setChecked] = useState(false);
+
+  const label = () => {
+    return (
+      <>
+        <div className="flex flex-row justify-start">
+          <TriangleIcon className="w-5 h-5 mr-2 text-gray-400" />
+          <div className='text-gray-800'>週間レポート登録をリマインド</div>
+        </div>
+      </>
+    );
+  };
+
+  return (
+    <>
+    <Radio.Group
+      name="select"
+      label={label()}
+      description="ONにすると毎週日曜日にお知らせします"
+    >
+      <Group mt="xs">
+        <Radio value="true" label="ON" color="#93c5fd"/>
+        <Radio value="false" label="OFF" color="#93c5fd"/>
+        <div className=''>
+      <Button variant='outline' size="xs" color='#9ca3af'>
+        更新
+        <ArrowPathIcon className="w-5 h-5 ml-2 text-blue-400" />
+    </Button>
+      </div>
+      </Group>
+    </Radio.Group>
+    </>
+  )
+}

--- a/app/components/page/Setting/Steps.tsx
+++ b/app/components/page/Setting/Steps.tsx
@@ -1,0 +1,38 @@
+import { TriangleIcon } from "../../ui/icon/Triangle"
+import Image from 'next/image';
+import AlertSelect from "./AlertSelect";
+import { BellAlertIcon } from "@heroicons/react/24/outline";
+
+export default function Steps() {
+  return (
+    <>
+      <div className="flex flex-col justify-center w-full max-w-lg">
+        <div className='flex justify-end pr-5 pb-2 pt-4'>
+          <div className='flex flex-row text-gray-600 text-sm items-center'>
+            <BellAlertIcon className="w-4 h-4 mr-1" />
+            <div>現在の設定：OFF</div>
+          </div>
+        </div>
+        <div className="bg-white rounded-md py-5 pl-7">
+          <div className="flex flex-row justify-start pt-3">
+            <TriangleIcon className="w-5 h-5 mr-2 ml-4 text-gray-400" />
+            <div className='text-sm text-gray-800'>通知には友達追加が必要です</div>
+            <div className='text-sm text-red-400'>＊</div>
+          </div>
+          <div className="flex py-3 pl-4">
+            <a href="https://lin.ee/iumtxW9" >
+              <Image
+                src="https://scdn.line-apps.com/n/line_add_friends/btn/ja.png" 
+                alt="友だち追加"
+                height="100"
+                width="100" />
+            </a>
+          </div>
+          <div className="flex py-5 pl-4">
+            <AlertSelect/>
+          </div>
+        </div>
+      </div>  
+    </>
+  )
+}

--- a/app/components/page/StepForm/HelpPage.tsx
+++ b/app/components/page/StepForm/HelpPage.tsx
@@ -11,7 +11,7 @@ export default function HelpPage() {
         <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
           <p>今週の振り返りを入力しましょう。</p>
           <p>⚠️ 実績は『今週のみ』確認可能です。</p>
-          <p>⚠️ 先週以降の実績はダッシュボードより確認してください。</p>
+          <p>⚠️ 先週以前の実績はダッシュボードより確認してください。</p>
         </div>
 
         <div className="flex items-center text-gray-700 underline border-t pt-2">

--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,10 @@ const nextConfig = {
           protocol: 'https',
           hostname: 'profile.line-scdn.net',
         },
+        {
+          protocol: 'https',
+          hostname: 'scdn.line-apps.com',
+        },
       ],
     },
     // reactStrictMode: false,


### PR DESCRIPTION
## 概要

通知設定ページの大枠を作成

issue: #52 

## 変更点

- settingページの追加

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0
- フッター、ヘッダーメニューからページを開くことができる

## 影響範囲
- /setting

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応