### PR TITLE
User Setting #53

### DIFF
--- a/app/api/setting/route.ts
+++ b/app/api/setting/route.ts
@@ -15,16 +15,11 @@ export async function GET() {
     });
   }
 
-  const railsUserId = session.user.railsId;
+  const userId = session.user.railsId;
   const apiUrl = process.env.RAILS_API_URL
 
   try {
-    const response = await axios.get(`${apiUrl}/users/notifications`, {
-      headers: {
-        'user': `${railsUserId}`,
-        'Content-Type': 'application/json',
-      },
-    });
+    const response = await axios.get(`${apiUrl}/users/${userId}/notifications`);
     return new Response(JSON.stringify(response.data), {
       status: 200,
       headers: {
@@ -38,6 +33,45 @@ export async function GET() {
       headers: {
         "Content-Type": "application/json",
       },
+    });
+  }
+}
+
+export async function PATCH(request: Request) {
+
+  const session = await getServerSession(options);
+    
+  if (!session) {
+    return new Response(JSON.stringify({ error: '認証が必要です' }), {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  const data = await request.json();
+  const user = data.user;
+  const userId = session.user.railsId; 
+  const apiUrl = process.env.RAILS_API_URL
+
+  try {
+    const response = await axios.patch(`${apiUrl}/users/${userId}/update_notifications`, { 
+      user
+    });
+      return new Response(JSON.stringify(response.data), {
+        status: 200,
+        headers: {
+            "Content-Type": "application/json",
+        },
+    });
+  } catch (error) {
+    console.error(error); 
+    return new Response(JSON.stringify({ error: '予期せぬエラーが発生しました'  }), {
+        status: 500,
+        headers: {
+          "Content-Type": "application/json",
+        },
     });
   }
 }

--- a/app/api/setting/route.ts
+++ b/app/api/setting/route.ts
@@ -1,0 +1,43 @@
+import axios from 'axios';
+import { getServerSession } from "next-auth/next"
+import { options } from '@/lib/options';
+
+export async function GET() {
+
+  const session = await getServerSession(options);
+    
+  if (!session) {
+    return new Response(JSON.stringify({ error: '認証が必要です' }), {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  const railsUserId = session.user.railsId;
+  const apiUrl = process.env.RAILS_API_URL
+
+  try {
+    const response = await axios.get(`${apiUrl}/users/notifications`, {
+      headers: {
+        'user': `${railsUserId}`,
+        'Content-Type': 'application/json',
+      },
+    });
+    return new Response(JSON.stringify(response.data), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    return new Response(JSON.stringify({ error:'予期せぬエラーが発生しました' }), {
+      status: 500,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+}

--- a/app/components/base/FooterMenu.tsx
+++ b/app/components/base/FooterMenu.tsx
@@ -79,7 +79,7 @@ export default function FooterMenu() {
         <FooterDrawer active={active} setActive={setActive} onClose={close}/>
       </Drawer >
 
-      <Drawer opened={openedUser} onClose={closeUser} size="30%" position="bottom" title={titleUser()} zIndex={5}>
+      <Drawer opened={openedUser} onClose={closeUser} size="40%" position="bottom" title={titleUser()} zIndex={5}>
         <ProfileDrawer active={active} setActive={setActive} onClose={closeUser}/>
       </Drawer>
     </>

--- a/app/components/page/Setting/AlertSelect.tsx
+++ b/app/components/page/Setting/AlertSelect.tsx
@@ -1,11 +1,24 @@
 "use client"
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Radio, Group, Button} from '@mantine/core';
 import { TriangleIcon } from '../../ui/icon/Triangle';
 import { ArrowPathIcon } from "@heroicons/react/24/outline";
 
 export default function AlertSelect() {
   const [checked, setChecked] = useState(false);
+
+  useEffect(() => {
+    const fetchNotifications = async () => {
+      try {
+        const response = await fetch(`/api/setting`);
+        const data = await response.json();
+        setChecked(data.notifications);
+      } catch (error) {
+        console.error('通知設定の取得に失敗しました', error);
+      }
+    };
+    fetchNotifications();
+  }, []);
 
   const label = () => {
     return (
@@ -20,22 +33,24 @@ export default function AlertSelect() {
 
   return (
     <>
-    <Radio.Group
-      name="select"
-      label={label()}
-      description="ONにすると毎週日曜日にお知らせします"
-    >
-      <Group mt="xs">
-        <Radio value="true" label="ON" color="#93c5fd"/>
-        <Radio value="false" label="OFF" color="#93c5fd"/>
-        <div className=''>
-      <Button variant='outline' size="xs" color='#9ca3af'>
-        更新
-        <ArrowPathIcon className="w-5 h-5 ml-2 text-blue-400" />
-    </Button>
-      </div>
-      </Group>
-    </Radio.Group>
+      <Radio.Group
+        name="select"
+        label={label()}
+        description="ONにすると毎週日曜日にお知らせします"
+        value={checked ? 'true' : 'false'}
+        onChange={(value) => setChecked(value === 'true')}
+      >
+        <Group mt="xs">
+          <Radio value="true" label="ON" color="#93c5fd"/>
+          <Radio value="false" label="OFF" color="#93c5fd"/>
+          <div>
+            <Button variant='outline' size="xs" color='#9ca3af'>
+              更新
+              <ArrowPathIcon className="w-5 h-5 ml-2 text-blue-400" />
+            </Button>
+          </div>
+        </Group>
+      </Radio.Group>
     </>
   )
 }

--- a/app/components/page/Setting/AlertSelect.tsx
+++ b/app/components/page/Setting/AlertSelect.tsx
@@ -1,24 +1,15 @@
-"use client"
-import { useState, useEffect } from 'react';
 import { Radio, Group, Button} from '@mantine/core';
 import { TriangleIcon } from '../../ui/icon/Triangle';
 import { ArrowPathIcon } from "@heroicons/react/24/outline";
 
-export default function AlertSelect() {
-  const [checked, setChecked] = useState(false);
+type AlertSelectProps = {
+  handleUpdate: () => Promise<void>;
+  checked: boolean;
+  setChecked: (checked: boolean) => void;
+  currentSetting: boolean;
+}
 
-  useEffect(() => {
-    const fetchNotifications = async () => {
-      try {
-        const response = await fetch(`/api/setting`);
-        const data = await response.json();
-        setChecked(data.notifications);
-      } catch (error) {
-        console.error('通知設定の取得に失敗しました', error);
-      }
-    };
-    fetchNotifications();
-  }, []);
+export default function AlertSelect({handleUpdate, checked, setChecked, currentSetting} :AlertSelectProps) {
 
   const label = () => {
     return (
@@ -30,6 +21,8 @@ export default function AlertSelect() {
       </>
     );
   };
+
+  const isButtonDisabled = checked === currentSetting;
 
   return (
     <>
@@ -44,7 +37,7 @@ export default function AlertSelect() {
           <Radio value="true" label="ON" color="#93c5fd"/>
           <Radio value="false" label="OFF" color="#93c5fd"/>
           <div>
-            <Button variant='outline' size="xs" color='#9ca3af'>
+            <Button variant='outline' size="xs" color='#9ca3af' onClick={handleUpdate} disabled={isButtonDisabled}>
               更新
               <ArrowPathIcon className="w-5 h-5 ml-2 text-blue-400" />
             </Button>

--- a/app/components/page/Setting/Steps.tsx
+++ b/app/components/page/Setting/Steps.tsx
@@ -1,16 +1,53 @@
-import { TriangleIcon } from "../../ui/icon/Triangle"
+"use client"
+import { useState, useEffect } from 'react';
 import Image from 'next/image';
-import AlertSelect from "./AlertSelect";
+import axios from 'axios'
+import { showSuccessNotification, showErrorNotification } from "@/utils/notifications";
+import { TriangleIcon } from "../../ui/icon/Triangle"
 import { BellAlertIcon } from "@heroicons/react/24/outline";
+import AlertSelect from "./AlertSelect";
 
 export default function Steps() {
+  const [checked, setChecked] = useState(false);
+  const [currentSetting, setCurrentSetting] = useState(false);
+
+  useEffect(() => {
+    const fetchNotifications = async () => {
+      try {
+        const response = await fetch(`/api/setting`);
+        const data = await response.json();
+        setChecked(data.notifications);
+        setCurrentSetting(data.notifications);
+      } catch (error) {
+        console.error('通知設定の取得に失敗しました', error);
+      }
+    };
+    fetchNotifications();
+  }, []);
+
+  const handleUpdate = async () => {
+    try {
+      await axios.patch(`/api/setting`, {
+        user: {
+          notifications: checked,
+        },
+      });
+      showSuccessNotification(`更新しました`);
+      setCurrentSetting(checked);
+    } catch (error) {
+      showErrorNotification('更新に失敗しました');
+      console.error("Failed to send weekly target", error);
+    }
+  };
+
   return (
     <>
       <div className="flex flex-col justify-center w-full max-w-lg">
         <div className='flex justify-end pr-5 pb-2 pt-4'>
           <div className='flex flex-row text-gray-600 text-sm items-center'>
             <BellAlertIcon className="w-4 h-4 mr-1" />
-            <div>現在の設定：OFF</div>
+            <div>現在の設定：</div>
+            <div className='text-gray-700 font-bold'>{currentSetting ? 'ON' : 'OFF'}</div>
           </div>
         </div>
         <div className="bg-white rounded-md py-5 pl-7">
@@ -29,7 +66,7 @@ export default function Steps() {
             </a>
           </div>
           <div className="flex py-5 pl-4">
-            <AlertSelect/>
+            <AlertSelect handleUpdate={handleUpdate} checked={checked} setChecked={setChecked} currentSetting={currentSetting}/>
           </div>
         </div>
       </div>  


### PR DESCRIPTION
## 概要

LINE通知機能実装

issue: #53 

## 変更点

- ページ表示時に現在の通知設定を取得し表示する
- ラジオボタンでON/OFF選択, 更新ボタンで設定変更（handleUpdate → APIルート → バックエンド）
- ラジオボタンの選択が現在の設定と同じ場合更新ボタンを押せない設定

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0
 - バックエンドと期待するデータの受け渡しができ、設定の更新ができることを確認

## 影響範囲
- /setting

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応