### PR TITLE
openAI API #47

### DIFF
--- a/app/api/monthlyreport/route.ts
+++ b/app/api/monthlyreport/route.ts
@@ -1,0 +1,92 @@
+import axios from 'axios';
+import { getServerSession } from "next-auth/next"
+import { options } from '@/lib/options';
+
+export async function GET() {
+
+  const session = await getServerSession(options);
+    
+  if (!session) {
+    return new Response(JSON.stringify({ error: '認証が必要です' }), {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  const railsUserId = session.user.railsId;
+  const apiUrl = process.env.RAILS_API_URL
+
+  try {
+    const response = await axios.get(`${apiUrl}/monthly_reports`, {
+      headers: {
+        'user': `${railsUserId}`,
+        'Content-Type': 'application/json',
+      },
+    });
+    return new Response(JSON.stringify(response.data), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    return new Response(JSON.stringify({ error:'予期せぬエラーが発生しました' }), {
+      status: 500,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+}
+
+export async function POST(request: Request) {
+
+  const session = await getServerSession(options);
+      
+  if (!session) {
+    return new Response(JSON.stringify({ error: '認証が必要です' }), {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  const data = await request.json();
+  const monthly_report = data.monthly_report;
+  
+  if (!monthly_report){
+    return new Response(JSON.stringify({ error: 'monthly_reportがありません' }), {
+        status: 400,
+        headers: {
+            "Content-Type": "application/json"
+        }
+    });
+  }
+
+  monthly_report.user_id = session.user.railsId;
+  const apiUrl = process.env.RAILS_API_URL
+
+  try {
+    const response = await axios.post(`${apiUrl}/monthly_reports`, { 
+      monthly_report
+    });
+    return new Response(JSON.stringify(response.data), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  } catch (error) {
+    console.error(error); 
+    return new Response(JSON.stringify({ error: '予期せぬエラーが発生しました'  }), {
+      status: 500,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+}

--- a/app/api/summary/route.ts
+++ b/app/api/summary/route.ts
@@ -1,0 +1,28 @@
+import { OpenAI } from 'openai';
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY
+});
+
+export async function POST(request: Request) {
+  try {
+    const data = await request.json();
+    const promptText = data.prompt;
+
+    if (!promptText) {
+      return new Response(JSON.stringify({ text: 'Prompt is required' }), { status: 400 });
+    }
+  
+    const completion = await openai.completions.create({
+      model: "text-davinci-003",
+      prompt: `次の週間レポートの内容を基に、300字以内の日本語で月間レポートとして要約してください：\n\n${promptText}`,
+      max_tokens: 2048
+    });
+  
+    const response = completion.choices[0].text?.trim() || 'Sorry, there was an error.';
+    return new Response(JSON.stringify({ text: response }), { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return new Response(JSON.stringify({ text: 'Server error' }), { status: 500 });
+  }
+}

--- a/app/components/page/Report/CreateInfo.tsx
+++ b/app/components/page/Report/CreateInfo.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import axios from 'axios'
 import { WeeklyReport } from '@/types';
 import { Button } from '@mantine/core';
@@ -40,7 +40,7 @@ export default function CreateInfo({reportsList, targetMonth}: CreateInfoProps) 
     }
   };
 
-  const saveSummary = async () => {
+  const saveSummary = useCallback(async () => {
     if (summaryData !== null) {
       try {
         await axios.post(`/api/monthlyreport`, {
@@ -56,13 +56,13 @@ export default function CreateInfo({reportsList, targetMonth}: CreateInfoProps) 
         return;
       }
     };
-  }
+  }, [summaryData, targetMonth]);
 
   useEffect(() => {
     if (!isLoading && summaryData) {
       saveSummary();
     }
-  }, [isLoading, summaryData]);
+  }, [isLoading, summaryData, saveSummary]);
 
   return (
     <>

--- a/app/components/page/Report/CreateInfo.tsx
+++ b/app/components/page/Report/CreateInfo.tsx
@@ -1,14 +1,90 @@
+"use client"
+import { useState, useEffect } from "react";
+import axios from 'axios'
+import { WeeklyReport } from '@/types';
 import { Button } from '@mantine/core';
 import { PaperAirplaneIcon } from '@heroicons/react/24/outline';
+import { showErrorNotification, showSuccessNotification } from '@/utils/notifications';
+import Loading from "../../ui/Loading";
 
-export default function CreateInfo() {
+type CreateInfoProps = {
+  reportsList: WeeklyReport[];
+  targetMonth: string;
+};
+
+type SummaryData = {
+  text: string;
+}
+
+export default function CreateInfo({reportsList, targetMonth}: CreateInfoProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [summaryData, setSummaryData] = useState<SummaryData | null>(null);
+
+  const combinedReportsContent = reportsList.map(report => report.content).join("\n\n");
+
+  const handleSubmit = async () => {
+    if (reportsList.length >= 3) {
+      setIsLoading(true);
+      try {
+        const response = await axios.post(`/api/summary`, { prompt: combinedReportsContent });
+        console.log((response.data))
+        setSummaryData(response.data as SummaryData);
+        setIsLoading(false); 
+
+      } catch (error) {
+        showErrorNotification('作成に失敗しました');
+        console.error("Failed", error);
+      }
+    } else {
+      showErrorNotification('レポートが３週以上必要です');
+    }
+  };
+
+  const saveSummary = async () => {
+    if (summaryData !== null) {
+      try {
+        await axios.post(`/api/monthlyreport`, {
+          monthly_report: {
+            content: summaryData.text,
+            month: targetMonth,
+          },
+        });
+        showSuccessNotification(`月間レポートを登録しました`);
+      } catch(error) {
+        showErrorNotification('保存に失敗しました。');
+        console.error("Failed to send weekly report", error);
+        return;
+      }
+    };
+  }
+
+  useEffect(() => {
+    if (!isLoading && summaryData) {
+      saveSummary();
+    }
+  }, [isLoading, summaryData]);
+
   return (
     <>
-      <div className="flex flex-row justify-center items-center px-7 md:px-12">
-        <Button variant="outline" color="#9ca3af" className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform" >
-          Create
-          <PaperAirplaneIcon className="w-5 h-5 ml-1 text-blue-400" />
-        </Button>
+      <div className="flex flex-col justify-center items-center px-7 md:px-12">
+        <div className="flex flex-row justify-center items-center px-7 md:px-12">
+          <Button 
+            variant="outline" 
+            color="#9ca3af" 
+            className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform"
+            onClick={handleSubmit}
+          >
+            Create
+            <PaperAirplaneIcon className="w-5 h-5 ml-1 text-blue-400" />
+          </Button>
+        </div>
+        <div className="flex flex-row justify-center items-center px-7 md:px-12 mt-3">
+          {isLoading ? (
+            <Loading size="xs" /> // ローディングコンポーネントを表示
+          ) : (
+            summaryData && <div>{summaryData.text}</div>
+          )}
+        </div>
       </div>
     </>
   )

--- a/app/components/page/Report/ReportArchive.tsx
+++ b/app/components/page/Report/ReportArchive.tsx
@@ -21,7 +21,6 @@ export default function ReportArchive() {
 
   const targetMonth = formatDateYM(value);
 
-
   const filteredWeeklyReports = weeklyReports.filter(report => {
     const reportMonth = report.start_date.substring(0, 7); 
     return reportMonth === targetMonth;
@@ -63,7 +62,7 @@ export default function ReportArchive() {
         </HelpMordal>
       </div>
 
-      <CreateInfo />
+      <CreateInfo reportsList={filteredWeeklyReports} targetMonth={targetMonth}/>
     </div>  
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "mantine-form-zod-resolver": "^1.0.0",
         "next": "14.0.3",
         "next-auth": "^4.24.5",
+        "openai": "^4.24.1",
         "react": "^18",
         "react-dom": "^18",
         "recharts": "^2.10.3",
@@ -1060,9 +1061,17 @@
       "version": "20.10.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.1.tgz",
       "integrity": "sha512-T2qwhjWwGH81vUEx4EXmBKsTJRXFXNZTL4v0gi01+zyBmCwzE6TyHszqX01m+QHTEq+EZNo13NeJIdEqf+Myrg==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.10",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.10.tgz",
+      "integrity": "sha512-PPpPK6F9ALFTn59Ka3BaL+qGuipRfxNE8qVgkp0bVixeiR2c2/L+IVOiBdu9JhhT22sWnQEp6YyHGI2b2+CMcA==",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -1205,6 +1214,17 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.11.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
@@ -1224,6 +1244,17 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+      "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -1550,6 +1581,11 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1691,6 +1727,14 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -1826,6 +1870,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/cssesc": {
@@ -2060,6 +2112,15 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true
+    },
+    "node_modules/digest-fetch": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-1.3.0.tgz",
+      "integrity": "sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==",
+      "dependencies": {
+        "base-64": "^0.1.0",
+        "md5": "^2.3.0"
+      }
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -2671,6 +2732,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -2837,6 +2906,31 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
+    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/fraction.js": {
@@ -3150,6 +3244,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
@@ -3303,6 +3405,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
@@ -3788,6 +3895,16 @@
         "zod": ">=3.0.0"
       }
     },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3853,8 +3970,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -3958,6 +4074,43 @@
       },
       "peerDependenciesMeta": {
         "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
           "optional": true
         }
       }
@@ -4132,6 +4285,33 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "4.24.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.24.1.tgz",
+      "integrity": "sha512-ezm/O3eiZMnyBqirUnWm9N6INJU1WhNtz+nK/Zj/2oyKvRz9pgpViDxa5wYOtyGYXPn1sIKBV0I/S4BDhtydqw==",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "digest-fetch": "^1.3.0",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7",
+        "web-streams-polyfill": "^3.2.1"
+      },
+      "bin": {
+        "openai": "bin/cli"
+      }
+    },
+    "node_modules/openai/node_modules/@types/node": {
+      "version": "18.19.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.4.tgz",
+      "integrity": "sha512-xNzlUhzoHotIsnFoXmJB+yWmBvFZgKCI9TtPIEdYIMM1KWfwuY8zh7wvc1u1OAXlC7dlf6mZVx/s+Y5KfFz19A==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "node_modules/openid-client": {
@@ -5343,6 +5523,11 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/ts-api-utils": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
@@ -5498,8 +5683,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
@@ -5671,6 +5855,28 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.2.tgz",
+      "integrity": "sha512-3pRGuxRF5gpuZc0W+EpwQRmCD7gRqcDOMt688KmdlDAgAyaB1XlN0zq2njfDNm44XVdIouE7pZ6GzbdyH47uIQ==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "mantine-form-zod-resolver": "^1.0.0",
     "next": "14.0.3",
     "next-auth": "^4.24.5",
+    "openai": "^4.24.1",
     "react": "^18",
     "react-dom": "^18",
     "recharts": "^2.10.3",


### PR DESCRIPTION
## 概要

openai API の導入。
選択した月の週間レポートをプロンプトとして渡し要約文を生成。
要約文をバックエンドに保存。
レスポンスを画面に表示するところまで。

issue: #47 

## 変更点

- openaiライブラリ導入
- APIルートの作成
- Loadingとレスポンスの表示（仮）

## 動作確認
macOS, Chromeブラウザ, Node -v18.17.0
- 生成中はLoadingが表示され、完了後画面に要約文が表示されることを確認
- バックエンドへの保存処理も続けて実行されることを確認

## 影響範囲
- /report

## チェックリスト

- [x] Lintチェックをパスした
- [ ] レスポンシブ対応

## コメント
UI未実装