### PR TITLE
Monthly report #49

### DIFF
--- a/app/components/page/Report/CreateInfo.tsx
+++ b/app/components/page/Report/CreateInfo.tsx
@@ -59,7 +59,7 @@ export default function CreateInfo({reportsList, targetMonth}: CreateInfoProps) 
         return;
       }
     };
-  }, [summaryData, targetMonth]);
+  }, [summaryData, targetMonth, fetchMonthlyReport]);
 
   useEffect(() => {
     if (!isLoading && summaryData) {

--- a/app/components/page/Report/CreateInfo.tsx
+++ b/app/components/page/Report/CreateInfo.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect, useCallback } from "react";
 import axios from 'axios'
 import { WeeklyReport } from '@/types';
+import useDashboardStore from "@/store/dashboardStore";
 import { Button } from '@mantine/core';
 import { PaperAirplaneIcon } from '@heroicons/react/24/outline';
 import { showErrorNotification, showSuccessNotification } from '@/utils/notifications';
@@ -19,6 +20,7 @@ type SummaryData = {
 export default function CreateInfo({reportsList, targetMonth}: CreateInfoProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [summaryData, setSummaryData] = useState<SummaryData | null>(null);
+  const fetchMonthlyReport = useDashboardStore((state) => state.fetchMonthlyReport);
 
   const combinedReportsContent = reportsList.map(report => report.content).join("\n\n");
 
@@ -29,8 +31,7 @@ export default function CreateInfo({reportsList, targetMonth}: CreateInfoProps) 
         const response = await axios.post(`/api/summary`, { prompt: combinedReportsContent });
         console.log((response.data))
         setSummaryData(response.data as SummaryData);
-        setIsLoading(false); 
-
+        setIsLoading(false);
       } catch (error) {
         showErrorNotification('作成に失敗しました');
         console.error("Failed", error);
@@ -50,6 +51,8 @@ export default function CreateInfo({reportsList, targetMonth}: CreateInfoProps) 
           },
         });
         showSuccessNotification(`月間レポートを登録しました`);
+        setSummaryData(null);
+        fetchMonthlyReport(true);
       } catch(error) {
         showErrorNotification('保存に失敗しました。');
         console.error("Failed to send weekly report", error);
@@ -63,28 +66,31 @@ export default function CreateInfo({reportsList, targetMonth}: CreateInfoProps) 
       saveSummary();
     }
   }, [isLoading, summaryData, saveSummary]);
-
+    
   return (
     <>
       <div className="flex flex-col justify-center items-center px-7 md:px-12">
-        <div className="flex flex-row justify-center items-center px-7 md:px-12">
-          <Button 
-            variant="outline" 
-            color="#9ca3af" 
-            className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform"
-            onClick={handleSubmit}
-          >
-            Create
-            <PaperAirplaneIcon className="w-5 h-5 ml-1 text-blue-400" />
-          </Button>
+
+        {summaryData === null ? (
+          <div className="flex flex-row justify-center items-center px-7 md:px-12">
+            <Button 
+              variant="outline" 
+              color="#9ca3af" 
+              className="shadow-md hover:translate-y-1 hover:text-sky-700 transition-transform"
+              onClick={handleSubmit}
+            >
+              Create
+              <PaperAirplaneIcon className="w-5 h-5 ml-1 text-blue-400" />
+            </Button>
+          </div>
+        ) : (
+          null
+        )}
+
+        <div className="flex flex-row justify-center items-center px-2 md:px-7 mt-3">
+          {isLoading && <Loading size="sm" /> }
         </div>
-        <div className="flex flex-row justify-center items-center px-7 md:px-12 mt-3">
-          {isLoading ? (
-            <Loading size="xs" /> // ローディングコンポーネントを表示
-          ) : (
-            summaryData && <div>{summaryData.text}</div>
-          )}
-        </div>
+
       </div>
     </>
   )

--- a/app/components/page/Report/CreateInfo.tsx
+++ b/app/components/page/Report/CreateInfo.tsx
@@ -37,7 +37,7 @@ export default function CreateInfo({reportsList, targetMonth}: CreateInfoProps) 
         console.error("Failed", error);
       }
     } else {
-      showErrorNotification('レポートが３週以上必要です');
+      showErrorNotification('レポートが３週分以上必要です');
     }
   };
 

--- a/app/components/page/Report/HelpPage.tsx
+++ b/app/components/page/Report/HelpPage.tsx
@@ -9,7 +9,7 @@ export default function HelpPage() {
           週間レポート一覧
         </div>
         <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
-          <p>登録した過去の週間レポートを月ごとに表示します。</p>
+          <p>登録した過去の週間レポートを月毎に表示します。</p>
           <p>各レポートはコピーボタンでコピー可能です。</p>
         </div>
 
@@ -18,7 +18,8 @@ export default function HelpPage() {
           月間レポートの作成について
         </div>
         <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
-          <p>週間レポートを３週分以上登録したら, それを元に月間レポートを自動で作成します。</p>
+          <p>週間レポートを要約し月間レポートを自動で作成します。</p>
+          <p className="text-red-400">⚠️ 月間レポートの作成には3週分以上の週間レポートが必要です。</p>
         </div>  
       </div>
     </>

--- a/app/components/page/Report/MonthlySummary.tsx
+++ b/app/components/page/Report/MonthlySummary.tsx
@@ -1,0 +1,28 @@
+import { Accordion } from '@mantine/core';
+import { FolderIcon } from "@heroicons/react/24/outline";
+import ReportContent from './ReportContent';
+
+type MonthlySummaryProps = {
+  content: string;
+}
+
+export default function MonthlySummary({content} :MonthlySummaryProps) {
+  return (
+    <>
+    <div className="px-7 md:px-14">
+      <Accordion variant="contained" defaultValue="summary">
+        <Accordion.Item key="monthlyーsummary" value="summary">
+          <Accordion.Control
+            icon={<FolderIcon className="w-6 h-6 ml-2 text-blue-300"/>}
+          >
+            まとめ
+          </Accordion.Control>
+          <Accordion.Panel>
+            <ReportContent content={content}/>
+          </Accordion.Panel>
+        </Accordion.Item>
+      </Accordion>
+    </div>
+  </>
+  )
+}

--- a/app/components/page/Report/ReportArchive.tsx
+++ b/app/components/page/Report/ReportArchive.tsx
@@ -11,12 +11,13 @@ import CreateInfo from "./CreateInfo";
 import { ArrowRightCircleIcon } from "@heroicons/react/24/outline";
 import HelpMordal from "../../ui/HelpMordal";
 import HelpPage from "./HelpPage";
+import MonthlySummary from "./MonthlySummary";
 
 export default function ReportArchive() {
   useFetchForReport();
   const router = useRouter();
 
-  const { weeklyReports } = useDashboardStore();
+  const { weeklyReports, monthlyReports } = useDashboardStore();
   const [value, setValue] = useState<Date | null>(new Date());
 
   const targetMonth = formatDateYM(value);
@@ -25,6 +26,8 @@ export default function ReportArchive() {
     const reportMonth = report.start_date.substring(0, 7); 
     return reportMonth === targetMonth;
   });
+
+  const selectedMonthReport = monthlyReports.find(report => report.month === targetMonth);
 
   return (
     <div className="flex flex-col justify-center w-full max-w-lg pt-4 pb-7 md:py-7 bg-white rounded-md">
@@ -54,15 +57,27 @@ export default function ReportArchive() {
 
       <ReportList reportsList={filteredWeeklyReports} />
 
-      <div className="flex flex-row justify-start px-7 pt-6 pb-4 md:px-12 items-center">
-        <TriangleIcon className="w-4 h-4 mr-1 ml-4 text-blue-300" />
-        <div className='text-sm text-gray-800 mr-2'>月間レポートを作成しますか？</div>
-        <HelpMordal>
-          <HelpPage/>
-        </HelpMordal>
-      </div>
-
-      <CreateInfo reportsList={filteredWeeklyReports} targetMonth={targetMonth}/>
+      {selectedMonthReport ? (
+        <>
+          <div className="flex flex-row justify-start px-7 pt-6 pb-4 md:px-12 items-center">
+            <TriangleIcon className="w-4 h-4 mr-1 ml-4 text-blue-300" />
+            <div className='text-sm text-gray-800 mr-2'>月間まとめ</div>
+          </div>
+          <MonthlySummary content={selectedMonthReport.content}/>
+        </>
+      ) : (
+        <>
+          <div className="flex flex-row justify-start px-7 pt-6 pb-4 md:px-12 items-center">
+            <TriangleIcon className="w-4 h-4 mr-1 ml-4 text-blue-300" />
+            <div className='text-sm text-gray-800 mr-2'>月間レポートを作成しますか？</div>
+            <HelpMordal>
+              <HelpPage/>
+            </HelpMordal>
+          </div>
+          <CreateInfo reportsList={filteredWeeklyReports} targetMonth={targetMonth}/>
+        </>
+      )}
+      
     </div>  
   )
 }

--- a/app/components/page/Setting/AlertSelect.tsx
+++ b/app/components/page/Setting/AlertSelect.tsx
@@ -23,6 +23,7 @@ export default function AlertSelect({handleUpdate, checked, setChecked, currentS
   };
 
   const isButtonDisabled = checked === currentSetting;
+  const icon = <ArrowPathIcon className='w-5 h-5 text-blue-400' />;
 
   return (
     <>
@@ -37,9 +38,8 @@ export default function AlertSelect({handleUpdate, checked, setChecked, currentS
           <Radio value="true" label="ON" color="#93c5fd"/>
           <Radio value="false" label="OFF" color="#93c5fd"/>
           <div>
-            <Button variant='outline' size="xs" color='#9ca3af' onClick={handleUpdate} disabled={isButtonDisabled}>
+            <Button variant='outline' size="xs" color='#9ca3af' rightSection={icon} onClick={handleUpdate} disabled={isButtonDisabled}>
               更新
-              <ArrowPathIcon className="w-5 h-5 ml-2 text-blue-400" />
             </Button>
           </div>
         </Group>

--- a/app/components/page/StepForm/HelpPage.tsx
+++ b/app/components/page/StepForm/HelpPage.tsx
@@ -10,16 +10,16 @@ export default function HelpPage() {
         </div>
         <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
           <p>今週の振り返りを入力しましょう。</p>
-          <p>⚠️ 実績は『今週のみ』確認可能です。</p>
-          <p>⚠️ 先週以前の実績はダッシュボードより確認してください。</p>
+          <p className="text-red-400">⚠️ 実績は『今週のみ』確認可能です。</p>
+          <p className="text-red-400">⚠️ 先週以前の実績はダッシュボードより確認してください。</p>
         </div>
 
         <div className="flex items-center text-gray-700 underline border-t pt-2">
           <CheckBadgeIcon className="w-6 h-6 text-blue-300 mr-2 font-bold" />
-          来週の目標設定
+          次週の目標設定
         </div>
         <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
-          <p>続けて入力できます。</p>
+          <p>振り返りをしたついでに次週の目標も設定しておきましょう。</p>
           <p>あとで設定したい場合はスキップボタンを押してください。</p>
         </div>  
       </div>

--- a/lib/useFetchData.ts
+++ b/lib/useFetchData.ts
@@ -65,7 +65,9 @@ export const useFetchForWeekly = () => {
 
 export const useFetchForReport = () => {
   const fetchWeeklyReport = useDashboardStore((state) => state.fetchWeeklyReport);
+  const fetchMonthlyReport = useDashboardStore((state) => state.fetchMonthlyReport);
   useEffect(() => {
     fetchWeeklyReport();
-  }, [fetchWeeklyReport]);
+    fetchMonthlyReport();
+  }, [fetchWeeklyReport, fetchMonthlyReport]);
 }

--- a/store/dashboardStore.ts
+++ b/store/dashboardStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { SalesRecord, WeeklyTarget, WeeklyReport, ProgressData, ResisteredDateRange, JobRecord, CustomersRecord } from '@/types';
+import { SalesRecord, WeeklyTarget, WeeklyReport, ProgressData, ResisteredDateRange, JobRecord, CustomersRecord, MonthlyReport } from '@/types';
 import { getThisWeekRange } from '@/utils/dateUtils';
 import { calculateTotal, calculateSetRate, calculateAverage } from '@/utils/calculateUtils';
 
@@ -10,6 +10,7 @@ type DashboardState = {
   registeredReportRanges: ResisteredDateRange[];
   weeklyTargets: WeeklyTarget[];
   registeredTargetRanges: ResisteredDateRange[];
+  monthlyReports: MonthlyReport[];
   thisWeekRecord: SalesRecord[];
   thisWeekAmount: number;
   thisWeekNumber: number;
@@ -24,6 +25,7 @@ type DashboardState = {
   fetchSalesRecord: (force?: boolean) => Promise<void>;
   fetchWeeklyReport: (force?: boolean) => Promise<void>;
   fetchWeeklyTarget: (force?: boolean) => Promise<void>;
+  fetchMonthlyReport:(force?: boolean) => Promise<void>;
   fetchJobsRecord: (force?: boolean) => Promise<void>;
   getThisWeekProgress: () => ProgressData;
   fetchCustomersRecord: (force?: boolean) => Promise<void>;
@@ -36,6 +38,7 @@ const useDashboardStore = create<DashboardState>((set, get) => ({
   registeredReportRanges: [], // 登録したレポートの日付データ
   weeklyTargets: [],
   registeredTargetRanges: [], // 登録した目標の日付データ
+  monthlyReports: [],
   thisWeekRecord: [],
   thisWeekAmount: 0,
   thisWeekNumber: 0,
@@ -151,6 +154,17 @@ const useDashboardStore = create<DashboardState>((set, get) => ({
         set({
           customersRecord: data
         });
+      } catch (error) {
+        console.error("Failed to fetch", error);
+      }
+    }
+  },
+  fetchMonthlyReport: async (force = false) => {
+    if (force || get().monthlyReports.length === 0) {
+      try {
+        const response = await fetch(`/api/monthlyreport`);
+        const data: MonthlyReport[] = await response.json();
+        set({ monthlyReports: data});
       } catch (error) {
         console.error("Failed to fetch", error);
       }

--- a/types/index.ts
+++ b/types/index.ts
@@ -19,6 +19,11 @@ export type WeeklyReport = {
   end_date: string;
 };
 
+export type MonthlyReport = {
+  content: string;
+  month: string;
+};
+
 export type WeeklyRecord = {
   amount: number;
   number: number;


### PR DESCRIPTION
## 概要

要約表示部分のUI, reportページ全体の調整

issue: #49 

## 変更点

- レスポンスをそのまま表示せず、バックエンドに保存後に表示する形に変更（再検討）
- UIの実装

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0
- バックエンド, APIルートと期待するデータの受け渡しができることを確認

## 影響範囲
- /report

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応