### PR TITLE
Refactoring2 #97

### DIFF
--- a/app/(authenticated)/weekly/page.tsx
+++ b/app/(authenticated)/weekly/page.tsx
@@ -2,7 +2,7 @@ import StepForm from '@/app/components/page/StepForm/StepForm';
 
 export default function Weekly() {
   return (
-    <div className="flex flex-col justify-center items-center mx-auto px-6 z-0 my-10 xl:my-20">
+    <div className="flex flex-col justify-center items-center mx-auto px-6 z-0 my-10">
       <StepForm />
     </div>
   );

--- a/app/(unauthenticated)/layout.tsx
+++ b/app/(unauthenticated)/layout.tsx
@@ -11,7 +11,7 @@ export default function UnauthenticatedLayout({
 
   return (
     <>
-      <div className="w-full z-30">
+      <div className="sticky top-0 w-full z-30">
         <AlertDemo/>
       </div>
       <div className="md:sticky top-12 w-full z-30">

--- a/app/components/page/Report/EditReportForm.tsx
+++ b/app/components/page/Report/EditReportForm.tsx
@@ -1,5 +1,6 @@
 "use client"
 import axios from 'axios'
+import { useState } from 'react';
 import { z } from 'zod';
 import { useForm } from '@mantine/form';
 import { zodResolver } from 'mantine-form-zod-resolver';
@@ -25,7 +26,7 @@ const schema  = z.object({
 });
 
 export default function EditReportForm({content, id, edit, setEdit} : ReportContentProps) {
-  
+  const [charCountError, setCharCountError] = useState('');
   const fetchMonthlyReport = useDashboardStore((state) => state.fetchMonthlyReport);
 
   const form = useForm({
@@ -34,6 +35,16 @@ export default function EditReportForm({content, id, edit, setEdit} : ReportCont
     },
     validate: zodResolver(schema),
   });
+
+  const handleContentChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const inputContent = event.target.value;
+    if (inputContent.length > 300) {
+      setCharCountError('300文字以内で入力してください');
+    } else {
+      setCharCountError('');
+    }
+    form.setFieldValue('newContent', inputContent);
+  };
 
   const handleUpdate = async (values: FormValues) => {
     if (values.newContent.trim() !== content.trim()) {
@@ -76,6 +87,8 @@ export default function EditReportForm({content, id, edit, setEdit} : ReportCont
             autosize
             minRows={14}
             maxRows={14}
+            onChange={handleContentChange}
+            error={charCountError} // エラーメッセージの表示
           />
         </div>
       </form>

--- a/app/components/page/Report/HelpPage.tsx
+++ b/app/components/page/Report/HelpPage.tsx
@@ -19,6 +19,13 @@ export default function HelpPage() {
         <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
           <p>週間レポートを要約し月間レポートを自動で作成します。</p>
           <p className="text-red-400">⚠️ 月間レポートの作成には3週分以上の週間レポートが必要です。</p>
+        </div>
+        <div className="flex items-center text-gray-700 underline border-t pt-2">
+          <CheckBadgeIcon className="w-6 h-6 text-blue-300 mr-2 font-bold" />
+          月間レポートの編集について
+        </div>
+        <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
+          <p>AIが作成した文章を元に300字以内で編集可能です。</p>
         </div>  
       </div>
     </>

--- a/app/components/page/StepForm/Confirmation.tsx
+++ b/app/components/page/StepForm/Confirmation.tsx
@@ -19,13 +19,13 @@ export default function Confirmation() {
         <span className="mx-1 text-sm text-gray-700">入力内容を確認して登録</span>
       </div>
       <div className="flex flex-row justify-center items-center w-full py-2">
-        <div className="flex flex-col w-full p-2 mx-auto justify-center">
+        <div className="flex flex-col w-full py-2 justify-center">
           <div className='flex flex-row ml-1 items-center mb-2'>
             <div className='text-sm text-gray-700 mr-1'>週間レポート :</div>
             <CalendarIcon className="w-4 h-4 text-gray-500 mx-1"/>
             <div className='text-sm text-gray-700'>{reportStartDate} ~ {reportEndDate}</div>
           </div>
-          <div className="bg-white border w-60 md:w-full h-32 overflow-auto text-xs p-2">
+          <div className="bg-white border md:w-full text-xs lg:text-sm p-2 h-32 overflow-auto">
             {weekly_report.content}
           </div>
         </div>

--- a/app/components/page/StepForm/Report.tsx
+++ b/app/components/page/StepForm/Report.tsx
@@ -23,7 +23,7 @@ export default function Report() {
       <Achievements/>
       <div className="flex flex-row justify-center items-center w-full">
         <div className="flex w-full py-2 justify-center">
-          <div className="w-full h-48 overflow-auto">
+          <div className="w-full h-48">
             <ReportInputForm/>
           </div>
         </div>

--- a/app/components/page/WeeklyReport.tsx/ReportInput.tsx
+++ b/app/components/page/WeeklyReport.tsx/ReportInput.tsx
@@ -1,8 +1,21 @@
+"use client"
+import { useState } from 'react';
 import useWeeklyStore from '@/store/weeklyStore';
 import { Textarea } from '@mantine/core';
 
 export default function ReportInputForm() {
+  const [charCountError, setCharCountError] = useState('');
   const { content, setContent } = useWeeklyStore();
+
+  const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const inputContent = e.currentTarget.value;
+    if (inputContent.length > 300) {
+      setCharCountError('300文字以内で入力してください');
+    } else {
+      setCharCountError('');
+    }
+    setContent(inputContent);
+  };
 
   return (
     <>
@@ -10,11 +23,12 @@ export default function ReportInputForm() {
         <form className='w-full'>
           <Textarea
             value={content}
-            onChange={(e) => setContent(e.currentTarget.value)}
+            onChange={handleContentChange}
             placeholder="今週の振り返り"
             description="300字以内で入力してください"
             label="週間レポート"
             size="xs"
+            error={charCountError} 
             withAsterisk
             autosize
             minRows={7}


### PR DESCRIPTION
## 概要

レイアウトの修正
フォーム入力中にバリデーション表示を追加

issue: #97 

## 変更点

- ページレイアウトの修正
- レポート入力、編集時に300字を超えたことがわかるようにエラー表示

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0

- 確定ボタン前、入力中文字数制限をオーバーした時点でエラーが表示される

## 影響範囲
- /weekly
- /dashboard/report
- /sample以下

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応
- [x] 必要なドキュメントを作成した
