### PR TITLE
Fix #106

### DIFF
--- a/app/features/demoPage/components/DemoReportStep.tsx
+++ b/app/features/demoPage/components/DemoReportStep.tsx
@@ -44,7 +44,7 @@ export default function DemoReportStep() {
       <div className="flex flex-row justify-center items-center w-full mt-3">
         <div className="flex w-full py-2 justify-center">
           <div className="w-full">
-            <ReportInputForm />
+            <ReportInputForm registeredReportRanges={registeredReportRangesDemo}/>
           </div>
         </div>
       </div>

--- a/app/features/demoPage/components/DemoTargetStep.tsx
+++ b/app/features/demoPage/components/DemoTargetStep.tsx
@@ -33,7 +33,7 @@ export default function DemoTargetStep() {
       <div className="flex flex-row justify-center items-center w-full">
         <div className="flex w-full p-2 mx-aut justify-center">
           <div className="w-60 md:w-full overflow-auto">
-            <TargetInputForm />
+            <TargetInputForm registeredTargetRanges={registeredTargetRangesDemo}/>
           </div>
         </div>
       </div>

--- a/app/features/report/components/HelpPage.tsx
+++ b/app/features/report/components/HelpPage.tsx
@@ -19,13 +19,14 @@ export default function HelpPage() {
         <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
           <p>週間レポートを要約し月間レポートを自動で作成します。</p>
           <p className="text-red-400">⚠️ 月間レポートの作成には3週分以上の週間レポートが必要です。</p>
+          <p className="text-red-400">⚠️ AIによる要約の精度にばらつきがある可能性がございます。</p>
         </div>
         <div className="flex items-center text-gray-700 underline border-t pt-2">
           <CheckBadgeIcon className="w-6 h-6 text-blue-300 mr-2 font-bold" />
           月間レポートの編集について
         </div>
         <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
-          <p>AIが作成した文章を元に300字以内で編集可能です。</p>
+          <p>AIが作成した文章を元に400字以内で編集可能です。</p>
         </div>  
       </div>
     </>

--- a/app/features/weekProgress/components/TargetInput.tsx
+++ b/app/features/weekProgress/components/TargetInput.tsx
@@ -13,6 +13,7 @@ type TargetInputProps = {
 
 export default function TargetInput({close} :TargetInputProps) {
   const { target, clearData } = useWeeklyStore();
+  const { registeredTargetRanges } = useDashboardStore();
   const { fetchWeeklyTarget } = useDashboardStore((state) => ({fetchWeeklyTarget: state.fetchWeeklyTarget}));
   const { start, end } = getThisWeekRange();
 
@@ -47,7 +48,7 @@ export default function TargetInput({close} :TargetInputProps) {
         </div>
       </div>
       <div className="flex p-2 mx-5 justify-center">
-        <TargetInputForm />
+        <TargetInputForm registeredTargetRanges={registeredTargetRanges}/>
       </div>
       <div className="flex p-2 mr-5 justify-end mt-2">
         <SubmitButton size="sm" type="submit" onClick={handleSubmit} />

--- a/app/features/weekly/components/ReportInput.tsx
+++ b/app/features/weekly/components/ReportInput.tsx
@@ -1,11 +1,21 @@
 "use client"
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { ResisteredDateRange } from '@/types';
 import useWeeklyStore from '@/store/weeklyStore';
 import { Textarea } from '@mantine/core';
+import { isDateInRanges } from '@/utils/dateUtils';
 
-export default function ReportInputForm() {
-  const [charCountError, setCharCountError] = useState('');
+type ReportInputFormProps = {
+  registeredReportRanges: ResisteredDateRange[];
+};
+
+export default function ReportInputForm({registeredReportRanges}: ReportInputFormProps) {
   const { content, setContent } = useWeeklyStore();
+  const { contentDateRange } = useWeeklyStore();
+  const [isFormDisabled, setFormDisabled] = useState(
+    isDateInRanges(contentDateRange[0], registeredReportRanges)
+  );
+  const [charCountError, setCharCountError] = useState('');
 
   const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const inputContent = e.currentTarget.value;
@@ -16,6 +26,10 @@ export default function ReportInputForm() {
     }
     setContent(inputContent);
   };
+
+  useEffect(() => {
+    setFormDisabled(isDateInRanges(contentDateRange[0], registeredReportRanges));
+  }, [contentDateRange, registeredReportRanges]);
 
   return (
     <>
@@ -33,6 +47,7 @@ export default function ReportInputForm() {
             autosize
             minRows={8}
             maxRows={14}
+            disabled={isFormDisabled}
           />
         </form>
       </div>

--- a/app/features/weekly/components/ReportStep.tsx
+++ b/app/features/weekly/components/ReportStep.tsx
@@ -7,7 +7,7 @@ import HelpMordal from '../../../components/ui/HelpMordal';
 import HelpPage from './HelpPage';
 
 export default function ReportStep() {
-  const { thisWeekTarget, thisWeekAmount, thisWeekNumber, thisWeekCount, thisWeekSet, thisWeekAverage } = useDashboardStore();
+  const { thisWeekTarget, thisWeekAmount, thisWeekNumber, thisWeekCount, thisWeekSet, thisWeekAverage, registeredReportRanges } = useDashboardStore();
   const { progressPercent, progress } = useDashboardStore((state) => state.getThisWeekProgress());
 
   return (
@@ -28,7 +28,7 @@ export default function ReportStep() {
       <div className="flex flex-row justify-center items-center w-full mt-3">
         <div className="flex w-full py-2 justify-center">
           <div className="w-full">
-            <ReportInputForm/>
+            <ReportInputForm registeredReportRanges={registeredReportRanges}/>
           </div>
         </div>
       </div>

--- a/app/features/weekly/components/RepotRangeInput.tsx
+++ b/app/features/weekly/components/RepotRangeInput.tsx
@@ -6,7 +6,7 @@ import WeekPicker from '../../../components/ui/WeekPicker';
 
 export default function ReportRangeInput() {
   const { contentDateRange, setContentDateRange } = useWeeklyStore();
-  const { registeredReportRanges } = useDashboardStore((state) => ({ registeredReportRanges: state.registeredReportRanges }));
+  const { registeredReportRanges } = useDashboardStore();
 
   const handleChange = (newValue: [Date | null, Date | null]) => {
     // 新しい週の範囲を計算してセットする

--- a/app/features/weekly/components/TargetInputForm.tsx
+++ b/app/features/weekly/components/TargetInputForm.tsx
@@ -1,8 +1,24 @@
-import { NumberInput } from '@mantine/core';
+"use client"
+import { useState, useEffect } from 'react';
+import { ResisteredDateRange } from '@/types';
+import { isDateInRanges } from '@/utils/dateUtils';
 import useWeeklyStore from '@/store/weeklyStore';
+import { NumberInput } from '@mantine/core';
 
-export default function TargetInputForm() {
+type TargetInputFormProps = {
+  registeredTargetRanges: ResisteredDateRange[];
+};
+
+export default function TargetInputForm({registeredTargetRanges}: TargetInputFormProps) {
   const { target, setTarget } = useWeeklyStore();
+  const { targetDateRange } = useWeeklyStore();
+  const [isFormDisabled, setFormDisabled] = useState(
+    isDateInRanges(targetDateRange[0], registeredTargetRanges)
+  );
+
+  useEffect(() => {
+    setFormDisabled(isDateInRanges(targetDateRange[0], registeredTargetRanges));
+  }, [targetDateRange, registeredTargetRanges]);
 
   return (
     <>
@@ -20,6 +36,7 @@ export default function TargetInputForm() {
             min={0}
             max={200}
             type="tel"
+            disabled={isFormDisabled}
           />
         </div>
       </div>

--- a/app/features/weekly/components/TargetStep.tsx
+++ b/app/features/weekly/components/TargetStep.tsx
@@ -1,8 +1,11 @@
+import useDashboardStore from '@/store/dashboardStore';
 import TargetInputForm from './TargetInputForm'
 import TargetRangeInput from './TargetRangeInput';
 import { FireIcon } from '@heroicons/react/24/outline';
 
 export default function TargetStep() {
+  const { registeredTargetRanges } = useDashboardStore();
+
   return (
     <div className="flex flex-col w-full mx-auto max-w-lg bg-white px-10 pb-10 pt-6 shadow-sm rounded">
       <div className="flex flex-row justify-center items-center w-full border-b pb-2 mb-2 md:hidden">
@@ -15,7 +18,7 @@ export default function TargetStep() {
       <div className="flex flex-row justify-center items-center w-full">
         <div className="flex w-full p-2 mx-aut justify-center">
           <div className="w-60 md:w-full overflow-auto">
-            <TargetInputForm />
+            <TargetInputForm registeredTargetRanges={registeredTargetRanges}/>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 概要

ステップ入力のフォーム入力制限を追加
ヘルプ修正

issue: #106 

## 変更点

- 登録済みの日との検証をInputコンポーネントにも追加
- 要約作成についての文言修正

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0
- 今週分のレポートが登録された状態で初期訪問時にレポート入力ができないことを確認

## 影響範囲
- /weekly
- /report

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応
