### PR TITLE
Task #112

### DIFF
--- a/app/components/page/Teams.tsx
+++ b/app/components/page/Teams.tsx
@@ -1,22 +1,24 @@
 "use client"
 import useFetchUser from "@/app/features/user/hooks/useUser";
 import useUserStore from "@/store/userStore";
-import TeamTask from "./TeamTask";
+import TeamTask from "../../features/teamTask/components/TaskTab";
 import TeamIntroduction from "./TeamIntroduction";
 import Loading from "../ui/Loading";
+import useFetchTask from "@/app/features/teamTask/hooks/useTeamTask";
 
 export default function Teams() {
   useFetchUser();
-  const { team } = useUserStore();
+  useFetchTask();
+  const { teamId } = useUserStore();
 
-  if (team === undefined) {
+  if (teamId === undefined) {
     return <Loading size="md"/>;
   }
 
   return (
     <>
       <div className="flex flex-col justify-center items-center mx-auto px-6 z-0 max-w-4xl mb-7 mt-4">
-        {team === "default" ? <TeamIntroduction /> : <TeamTask /> }
+        {teamId === 1 ? <TeamIntroduction /> : <TeamTask /> }
       </div>
     </>
   )

--- a/app/components/ui/UserImage.tsx
+++ b/app/components/ui/UserImage.tsx
@@ -9,7 +9,7 @@ const UserImage = ({ image, name }: UserImage) => {
     <div className="flex items-center cursor-pointer">
       <Image
         src={imageUrl}
-        className="w-8 h-8 rounded-full"
+        className="rounded-full"
         alt={userName}
         width={32}
         height={32}

--- a/app/features/teamTask/api/completeTask/[taskId]/route.ts
+++ b/app/features/teamTask/api/completeTask/[taskId]/route.ts
@@ -1,0 +1,52 @@
+import axios from 'axios';
+import { getJwt } from '@/lib/getJwt';
+import { NextRequest } from 'next/server';
+
+const endpoint = "tasks";
+const apiUrl = process.env.RAILS_API_URL
+
+export async function PATCH(req: NextRequest, { params }: { params: { taskId: string } }) {
+  const { accessToken } = await getJwt(req);
+  const id = params.taskId
+
+  if (!accessToken) {
+    return new Response(JSON.stringify({ error: '認証が必要です' }), {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+    
+  if (!id){
+    return new Response(JSON.stringify({ error: 'taskがありません' }), {
+      status: 400,
+      headers: {
+        "Content-Type": "application/json"
+      }
+    });
+  }
+  
+  try {
+    const response = await axios.patch(`${apiUrl}/${endpoint}/${id}/complete`, {}, {
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      }
+    });
+      return new Response(JSON.stringify(response.data), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+      },
+    });
+  } catch (error) {
+    console.error(error); 
+    return new Response(JSON.stringify({ error: '予期せぬエラーが発生しました'  }), {
+      status: 500,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+}

--- a/app/features/teamTask/api/createTask/route.ts
+++ b/app/features/teamTask/api/createTask/route.ts
@@ -1,0 +1,57 @@
+import axios from 'axios';
+import { getJwt } from '@/lib/getJwt';
+import { NextRequest } from 'next/server';
+
+const endpoint = "tasks";
+const apiUrl = process.env.RAILS_API_URL
+
+export async function POST(req: NextRequest) {
+  const { accessToken, userId } = await getJwt(req);
+        
+  if (!accessToken) {
+    return new Response(JSON.stringify({ error: '認証が必要です' }), {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  const data = await req.json();
+  const task = data.task;
+  task.user_id = userId;
+    
+  if (!task){
+    return new Response(JSON.stringify({ error: 'monthly_reportがありません' }), {
+      status: 400,
+      headers: {
+        "Content-Type": "application/json"
+      }
+    });
+  }
+  
+  try {
+    const response = await axios.post(`${apiUrl}/${endpoint}`, { 
+      task
+    }, {
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      }
+    });
+    return new Response(JSON.stringify(response.data), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  } catch (error) {
+    console.error(error); 
+    return new Response(JSON.stringify({ error: '予期せぬエラーが発生しました'  }), {
+      status: 500,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+}

--- a/app/features/teamTask/api/deleteTask/[taskId]/route.ts
+++ b/app/features/teamTask/api/deleteTask/[taskId]/route.ts
@@ -5,9 +5,10 @@ import { NextRequest } from 'next/server';
 const endpoint = "tasks";
 const apiUrl = process.env.RAILS_API_URL
 
-export async function POST(req: NextRequest) {
-  const { accessToken, userId } = await getJwt(req);
-        
+export async function DELETE(req: NextRequest, { params }: { params: { taskId: string } } ) {
+  const { accessToken } = await getJwt(req);
+  const id = params.taskId
+      
   if (!accessToken) {
     return new Response(JSON.stringify({ error: '認証が必要です' }), {
       status: 401,
@@ -16,12 +17,8 @@ export async function POST(req: NextRequest) {
       },
     });
   }
-
-  const data = await req.json();
-  const task = data.task;
-  task.user_id = userId;
-    
-  if (!task){
+  
+  if (!id){
     return new Response(JSON.stringify({ error: 'taskがありません' }), {
       status: 400,
       headers: {
@@ -31,18 +28,16 @@ export async function POST(req: NextRequest) {
   }
   
   try {
-    const response = await axios.post(`${apiUrl}/${endpoint}`, { 
-      task
-    }, {
+    const response = await axios.delete(`${apiUrl}/${endpoint}/${id}`, {
       headers: {
         'Authorization': `Bearer ${accessToken}`,
         'Content-Type': 'application/json',
       }
     });
-    return new Response(JSON.stringify(response.data), {
-      status: 200,
-      headers: {
-        "Content-Type": "application/json",
+      return new Response(JSON.stringify(response.data), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
       },
     });
   } catch (error) {

--- a/app/features/teamTask/api/editTask/route.ts
+++ b/app/features/teamTask/api/editTask/route.ts
@@ -1,0 +1,63 @@
+import axios from 'axios';
+import { getJwt } from '@/lib/getJwt';
+import { NextRequest } from 'next/server';
+
+const endpoint = "tasks";
+const apiUrl = process.env.RAILS_API_URL
+
+export async function PATCH(req: NextRequest) {
+  const { accessToken } = await getJwt(req);
+      
+  if (!accessToken) {
+    return new Response(JSON.stringify({ error: '認証が必要です' }), {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+  
+  const data = await req.json();
+  const task = data.task;
+  const taskId = data.task.id;
+    
+  if (!task){
+    return new Response(JSON.stringify({ error: 'monthly_reportがありません' }), {
+      status: 400,
+      headers: {
+        "Content-Type": "application/json"
+      }
+    });
+  }
+  
+  try {
+    const response = await axios.patch(`${apiUrl}/${endpoint}/${taskId}`, { 
+      task:{
+        is_group_task: data.task.is_group_task,
+        title: data.task.title,
+        importance: data.task.importance,
+        deadline: data.task.deadline,
+        group_id: data.task.group_id,
+      }
+    }, {
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      }
+    });
+      return new Response(JSON.stringify(response.data), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+      },
+    });
+  } catch (error) {
+    console.error(error); 
+    return new Response(JSON.stringify({ error: '予期せぬエラーが発生しました'  }), {
+      status: 500,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+}

--- a/app/features/teamTask/api/getTasks/route.ts
+++ b/app/features/teamTask/api/getTasks/route.ts
@@ -1,0 +1,35 @@
+import { getJwt } from '@/lib/getJwt';
+import { NextRequest } from 'next/server';
+import { fetchDataFromApi } from '@/lib/fetchDataFromApi';
+
+const endpoint = "tasks";
+
+export async function GET(req: NextRequest) {
+  const { accessToken } = await getJwt(req);
+
+  if (!accessToken) {
+    return new Response(JSON.stringify({ error: '認証が必要です' }), {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  try {
+    const data = await fetchDataFromApi(endpoint, accessToken);
+    return new Response(JSON.stringify(data), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  } catch (error) {
+    return new Response(JSON.stringify({ error:'予期せぬエラーが発生しました' }), {
+      status: 500,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+}

--- a/app/features/teamTask/api/updateTask/[taskId]/route.ts
+++ b/app/features/teamTask/api/updateTask/[taskId]/route.ts
@@ -5,8 +5,9 @@ import { NextRequest } from 'next/server';
 const endpoint = "tasks";
 const apiUrl = process.env.RAILS_API_URL
 
-export async function PATCH(req: NextRequest) {
+export async function PATCH(req: NextRequest, { params }: { params: { taskId: string } }) {
   const { accessToken } = await getJwt(req);
+  const id = params.taskId
       
   if (!accessToken) {
     return new Response(JSON.stringify({ error: '認証が必要です' }), {
@@ -19,10 +20,9 @@ export async function PATCH(req: NextRequest) {
   
   const data = await req.json();
   const task = data.task;
-  const taskId = data.task.id;
     
   if (!task){
-    return new Response(JSON.stringify({ error: 'monthly_reportがありません' }), {
+    return new Response(JSON.stringify({ error: 'taskがありません' }), {
       status: 400,
       headers: {
         "Content-Type": "application/json"
@@ -31,14 +31,8 @@ export async function PATCH(req: NextRequest) {
   }
   
   try {
-    const response = await axios.patch(`${apiUrl}/${endpoint}/${taskId}`, { 
-      task:{
-        is_group_task: data.task.is_group_task,
-        title: data.task.title,
-        importance: data.task.importance,
-        deadline: data.task.deadline,
-        group_id: data.task.group_id,
-      }
+    const response = await axios.patch(`${apiUrl}/${endpoint}/${id}`, { 
+      task
     }, {
       headers: {
         'Authorization': `Bearer ${accessToken}`,

--- a/app/features/teamTask/components/CreateTask.tsx
+++ b/app/features/teamTask/components/CreateTask.tsx
@@ -20,9 +20,16 @@ export default function CreateTask() {
     );
   };
 
+  const initialValues = {
+    isTeamTask: '',
+    title: '',
+    importance: 0,
+    deadline: new Date(),
+  }
+
   return (
     <>
-      <div className='flex flex-row items-center pb-3'>
+      <div className='flex flex-row items-center pb-3 mb-2'>
         <div className='text-sm text-gray-600 mr-2'>タスクを追加する</div>
         <ActionIcon variant="outline" color="#94a3b8" size="md" onClick={open} className="shadow-md hover:text-sky-700 transition-transform">
           <PlusIcon className='w-12 h-12 p-1' />
@@ -37,7 +44,7 @@ export default function CreateTask() {
         title={renderModalTitle()}
       >
         <div className="flex w-full px-6 py-4">
-          <InputForm endpoint='createTask'/>
+          <InputForm endpoint='createTask' initialValues={initialValues} close={close}/>
         </div>
       </Modal>
     </>

--- a/app/features/teamTask/components/CreateTask.tsx
+++ b/app/features/teamTask/components/CreateTask.tsx
@@ -1,6 +1,6 @@
 "use client"
 import { useDisclosure } from '@mantine/hooks';
-import { ActionIcon, Modal } from '@mantine/core';
+import { Modal, Button } from '@mantine/core';
 import { PlusIcon, PencilIcon } from "@heroicons/react/24/outline"
 import InputForm from './InputForm';
 
@@ -29,11 +29,11 @@ export default function CreateTask() {
 
   return (
     <>
-      <div className='flex flex-row items-center pb-3 mb-2'>
-        <div className='text-sm text-gray-600 mr-2'>タスクを追加する</div>
-        <ActionIcon variant="outline" color="#94a3b8" size="md" onClick={open} className="shadow-md hover:text-sky-700 transition-transform">
-          <PlusIcon className='w-12 h-12 p-1' />
-        </ActionIcon>
+      <div className='flex flex-row items-center bg-white'>
+        <Button size="sm" variant="outline" color="#9ca3af" onClick={open}>
+          NEW
+          <PlusIcon className="w-5 h-5 ml-1 text-sky-700" />
+        </Button>
       </div>
 
       <Modal
@@ -44,7 +44,7 @@ export default function CreateTask() {
         title={renderModalTitle()}
       >
         <div className="flex w-full px-6 py-4">
-          <InputForm endpoint='createTask' initialValues={initialValues} close={close}/>
+          <InputForm endpoint='createTask' initialValues={initialValues} close={close} label="追加する"/>
         </div>
       </Modal>
     </>

--- a/app/features/teamTask/components/CreateTask.tsx
+++ b/app/features/teamTask/components/CreateTask.tsx
@@ -1,0 +1,45 @@
+"use client"
+import { useDisclosure } from '@mantine/hooks';
+import { ActionIcon, Modal } from '@mantine/core';
+import { PlusIcon, PencilIcon } from "@heroicons/react/24/outline"
+import InputForm from './InputForm';
+
+export default function CreateTask() {
+  const [opened, { open, close }] = useDisclosure(false);
+
+  const renderModalTitle = () => {
+    return (
+      <>
+        <div className='flex flex-row items-start w-full pt-4 pr-22 mr-16 mb-1 text-md font-bold text-gray-600'>
+          <div className='flex w-full ml-2 items-center'>
+            <PencilIcon className="w-8 h-8 text-gray-500 mr-2" />
+            タスクを作成する
+          </div>
+        </div>
+      </>
+    );
+  };
+
+  return (
+    <>
+      <div className='flex flex-row items-center pb-3'>
+        <div className='text-sm text-gray-600 mr-2'>タスクを追加する</div>
+        <ActionIcon variant="outline" color="#94a3b8" size="md" onClick={open} className="shadow-md hover:text-sky-700 transition-transform">
+          <PlusIcon className='w-12 h-12 p-1' />
+        </ActionIcon>
+      </div>
+
+      <Modal
+        opened={opened}
+        onClose={close}
+        centered
+        size="md"
+        title={renderModalTitle()}
+      >
+        <div className="flex w-full px-6 py-4">
+          <InputForm endpoint='createTask'/>
+        </div>
+      </Modal>
+    </>
+  )
+}

--- a/app/features/teamTask/components/InputForm.tsx
+++ b/app/features/teamTask/components/InputForm.tsx
@@ -1,0 +1,121 @@
+"use client"
+import axios from 'axios'
+import { z } from 'zod';
+import { zodResolver } from 'mantine-form-zod-resolver';
+import useUserStore from '@/store/userStore';
+import useTaskStore from '@/store/taskStore';
+import { fetchTasks } from '../hooks/fetchTask';
+import { showSuccessNotification, showErrorNotification } from '@/utils/notifications';
+import { formatDate } from '@/utils/dateUtils';
+import { useForm } from '@mantine/form';
+import { DatePickerInput } from '@mantine/dates';
+import { TextInput, Radio, Group, Rating } from "@mantine/core"
+import { TriangleIcon } from '@/app/components/ui/icon/Triangle';
+import PlusButton from '@/app/components/ui/button/PlusButton';
+
+type InputFormProps = {
+  endpoint: string;
+}
+
+type FormValues = {
+  isTeamTask: string;
+  title: string;
+  importance: number;
+  deadline: Date;
+};
+
+const schema  = z.object({
+  isTeamTask: z.string().refine(val => val !== undefined, { message: "グループの選択は必須です" }),
+  title: z.string().min(1,  { message: '1~20文字で入力してください' }).max(20, { message: '1~20文字で入力してください' }),
+  importance: z.number().refine(val => val !== undefined, { message: "重要度の選択は必須です" }),
+  deadline: z.date().refine(val => val !== undefined, { message: "期限の設定は必須です" }),  
+});
+
+export default function InputForm({endpoint}: InputFormProps) {
+  const { setTasks } = useTaskStore(); 
+  const { teamId } = useUserStore();
+
+  const form = useForm({
+    initialValues: {
+      isTeamTask: '',
+      title: '',
+      importance: 0,
+      deadline: new Date(),
+    },
+    validate: zodResolver(schema),
+  });
+
+  const handleSubmit = async(values: FormValues) => {
+    try {
+      await axios.post(`/features/teamTask/api/${endpoint}`, {
+        task: {
+          is_group_task: values.isTeamTask === 'true',
+          title: values.title,
+          importance: values.importance - 1,
+          deadline: formatDate(values.deadline),
+          group_id: teamId,
+        },
+      });
+      showSuccessNotification(`登録しました`);
+      fetchTasks(setTasks);
+      form.reset();
+    } catch (error) {
+      showErrorNotification('登録に失敗しました。');
+    }
+  };
+    
+  return (
+    <>
+      <div className="flex flex-col justify-center items-center w-full">
+        <form onSubmit={form.onSubmit(handleSubmit)} className='w-full'>
+          <div className="flex flex-row items-center">
+            <TriangleIcon className="w-4 h-4 mr-2 text-sky-800" />
+          <div className='text-gray-800'>タスクの種類</div>
+        </div>
+        <Radio.Group
+          {...form.getInputProps('isTeamTask')}
+          name="isTeamTask"
+          className='mb-5'
+        >
+          <Group mt="xs">
+            <Radio value="true" label="チーム" color="#93c5fd"/>
+            <Radio value="false" label="自分" color="#93c5fd"/>
+          </Group>
+        </Radio.Group>
+
+        <div className="flex flex-row items-center">
+          <TriangleIcon className="w-4 h-4 mr-2 text-sky-800" />
+          <div className='text-gray-800'>タスク名</div>
+        </div>
+        <TextInput
+          {...form.getInputProps('title')}
+          name="title" 
+          placeholder="例：DM作成, スタイリング撮影 など"
+          description="1~20文字で入力してください"
+          className='mb-5'
+        />
+
+        <div className="flex flex-row items-center">
+          <TriangleIcon className="w-4 h-4 mr-2 text-sky-800" />
+          <div className='text-gray-800'>優先度</div>
+        </div>
+        <Rating count={3} size="lg" className='mt-2 mb-5' {...form.getInputProps('importance')}/>
+
+        <div className="flex flex-row items-center">
+          <TriangleIcon className="w-4 h-4 mr-2 text-sky-800" />
+          <div className='text-gray-800'>期限</div>
+        </div>
+        <DatePickerInput
+          {...form.getInputProps('deadline')}
+          placeholder="完了したい日付の選択"
+          className='mt-3 mb-5'
+        />
+
+        <div className="flex justify-center w-full mt-4">
+          <PlusButton size="sm" type="submit">追加する</PlusButton>
+        </div>
+      </form>
+    </div>
+  </>
+  )
+}

--- a/app/features/teamTask/components/Switch.tsx
+++ b/app/features/teamTask/components/Switch.tsx
@@ -1,0 +1,17 @@
+"use client"
+import { useState } from 'react';
+import { Switch } from '@mantine/core';
+
+export default function SwithTask() {
+  const [checked, setChecked] = useState(false);
+  return (
+    <div className='flex flex-row ml-5 items-center'>
+      <div className='text-xs mr-2'>完了タスクを表示</div>
+      <Switch
+        checked={checked}
+        onChange={(event) => setChecked(event.currentTarget.checked)}
+        size="md"
+      />
+    </div>
+  );
+}

--- a/app/features/teamTask/components/Switch.tsx
+++ b/app/features/teamTask/components/Switch.tsx
@@ -1,16 +1,38 @@
 "use client"
-import { useState } from 'react';
 import { Switch } from '@mantine/core';
 
-export default function SwithTask() {
-  const [checked, setChecked] = useState(false);
+type SwitchProps = {
+  checked: boolean;
+  setChecked: (checked: boolean) => void;
+}
+
+export default function SwithTask({ checked, setChecked }: SwitchProps) {
+
+  const offLabel = () => {
+    return (
+      <div className='px-1'>
+        未完了タスク
+      </div>
+    );
+  };
+
+  const onLabel = () => {
+    return (
+      <div className='px-1'>
+        完了済み
+      </div>
+    );
+  };
+
   return (
     <div className='flex flex-row ml-5 items-center'>
-      <div className='text-xs mr-2'>完了タスクを表示</div>
       <Switch
         checked={checked}
         onChange={(event) => setChecked(event.currentTarget.checked)}
-        size="md"
+        size="lg"
+        color="#94a3b8"
+        onLabel={onLabel()}
+        offLabel={offLabel()}
       />
     </div>
   );

--- a/app/features/teamTask/components/TaskActions.tsx
+++ b/app/features/teamTask/components/TaskActions.tsx
@@ -1,0 +1,65 @@
+"use client"
+import axios from 'axios';
+import { Task } from '@/types';
+import { showSuccessNotification, showErrorNotification } from '@/utils/notifications';
+import { fetchTasks } from '../hooks/fetchTask';
+import useTaskStore from '@/store/taskStore';
+import { ActionIcon } from "@mantine/core"
+import { PencilSquareIcon, TrashIcon } from "@heroicons/react/24/outline"
+
+type EditButtonsProps = {
+  task: Task;
+  setCurrentEditingTask: (task: Task) => void;
+  open: () => void;
+  close: () => void;
+}
+
+export default function TaskActions({ task, setCurrentEditingTask, open, close }: EditButtonsProps) {
+  const { setTeamTasks, setUserTasks } = useTaskStore(); 
+
+  const handleEditButtonClick = (task: Task) => {
+    setCurrentEditingTask(task);
+    open();
+  };
+  
+  const handleDelete = async(taskId: number) => {
+    const isConfirmed = confirm("削除しますか？");
+    if (!isConfirmed) {
+      return;
+    }
+    try {
+      await axios.delete(`/features/teamTask/api/deleteTask/${taskId}`);
+      showSuccessNotification(`削除しました`);
+      fetchTasks({setTeamTasks, setUserTasks});
+      close();
+    } catch (error) {
+      showErrorNotification('削除に失敗しました。');
+    }
+  };
+
+  return (
+    <>
+      <div className='flex pr-1 items-center'>
+        <ActionIcon 
+          variant="outline"
+          color="#cbd5e1" 
+          size="md" 
+          className="shadow-md hover:text-gray-500 transition-transform"
+          onClick={() => handleEditButtonClick(task)}
+        >
+          <PencilSquareIcon className='w-8 h-8 p-1' />
+        </ActionIcon>
+
+        <ActionIcon 
+          variant="outline" 
+          color="#cbd5e1" 
+          size="md" 
+          className="shadow-md hover:text-gray-500 transition-transform ml-2"
+          onClick={() => handleDelete(task.id)}
+        >
+          <TrashIcon className='w-8 h-8 p-1' />
+        </ActionIcon>
+      </div>
+    </>
+  )
+}

--- a/app/features/teamTask/components/TaskActions.tsx
+++ b/app/features/teamTask/components/TaskActions.tsx
@@ -42,7 +42,7 @@ export default function TaskActions({ task, setCurrentEditingTask, open, close }
       <div className='flex pr-1 items-center'>
         <ActionIcon 
           variant="outline"
-          color="#cbd5e1" 
+          color="#94a3b8" 
           size="md" 
           className="shadow-md hover:text-gray-500 transition-transform"
           onClick={() => handleEditButtonClick(task)}
@@ -52,7 +52,7 @@ export default function TaskActions({ task, setCurrentEditingTask, open, close }
 
         <ActionIcon 
           variant="outline" 
-          color="#cbd5e1" 
+          color="#94a3b8" 
           size="md" 
           className="shadow-md hover:text-gray-500 transition-transform ml-2"
           onClick={() => handleDelete(task.id)}

--- a/app/features/teamTask/components/TaskCard.tsx
+++ b/app/features/teamTask/components/TaskCard.tsx
@@ -1,11 +1,14 @@
 "use client"
+import axios from 'axios'
 import { useState } from 'react';
 import { Task } from '@/types';
 import { formatDateLayoutMMDD } from '@/utils/dateUtils';
 import { Checkbox, Tooltip, Rating } from "@mantine/core"
-import { ClockIcon, UserIcon } from '@heroicons/react/24/outline';
-import { UsersIcon } from '@heroicons/react/24/solid';
+import { CheckIcon, ClockIcon, MegaphoneIcon, UserIcon } from '@heroicons/react/24/outline';
 import TaskActions from './TaskActions';
+import { showSuccessNotification, showErrorNotification } from '@/utils/notifications';
+import { fetchTasks } from '../hooks/fetchTask';
+import useTaskStore from '@/store/taskStore';
 
 type TaskCardProps = {
   task: Task;
@@ -16,21 +19,52 @@ type TaskCardProps = {
 }
 
 export default function TaskCard({ task, editableTaskIds, setCurrentEditingTask, open, close }: TaskCardProps) {
-  const [checked, setChecked] = useState(false);
+  const [selectedTask, setSelectedTask] = useState<Task | null>(null);
+  const { setTeamTasks, setUserTasks, userTasks  } = useTaskStore(); 
+  const userTaskIds = userTasks.map(task => task.id);
+
+  const handleChange = (task: Task) => {
+    setSelectedTask(task);
+    if (task.isCompleted) {
+      return;
+    }
+    handleComplete(task.id);
+  };
+
+  const handleComplete = async(taskId: number) => {
+    const isConfirmed = confirm("完了しましたか？");
+    if (!isConfirmed) {
+      return;
+    }
+    try {
+      await axios.patch(`/features/teamTask/api/completeTask/${taskId}`);
+      showSuccessNotification(`完了しました`);
+      fetchTasks({setTeamTasks, setUserTasks});
+      setSelectedTask(null);
+    } catch (error) {
+      showErrorNotification('更新に失敗しました。');
+    }
+  };
+
+  const isCheckboxEnabled = task.isGroupTask || userTaskIds.includes(task.id);
+
+  const taskColorClass = task.isGroupTask ? '#93c5fd' : '#0369a1';
+
   return (
     <>
       <div className={`h-full flex items-center p-4 rounded-lg bg-white shadow-md border-4 
-                            ${task.isGroupTask ? 'border-blue-100' : 'border-orange-100'}`}
+                            ${task.isGroupTask ? 'border-blue-100' : 'border-blue-50'}`}
       >
         <div className='flex mr-4'>
           <Tooltip label="DONE?" arrowOffset={50} arrowSize={5} withArrow>
             <Checkbox
               size='lg'
-              color="#93c5fd"
-              checked={checked}
-              onChange={(event) => setChecked(event.currentTarget.checked)}
+              color={taskColorClass}
+              checked={task.isCompleted}
+              onChange={() => handleChange(task)}
               className="shadow-md"
               variant="outline"
+              disabled={!isCheckboxEnabled}
             />
           </Tooltip>
         </div>
@@ -39,25 +73,37 @@ export default function TaskCard({ task, editableTaskIds, setCurrentEditingTask,
           <div className='flex flex-row items-center border-t pt-2'>
             <ClockIcon className='w-5 h-5 text-gray-500 ml-2 lg:ml-4 mr-1' />
             <div className="text-gray-600 text-sm mr-3 lg:mr-5">{formatDateLayoutMMDD(task.deadline)}</div>
-            <Rating size="sm" count={3} color="#93c5fd" value={task.importance} readOnly/>
+            <Rating size="sm" count={3} color={taskColorClass} value={task.importance} readOnly/>
           </div>
           <div className='flex flex-row justify-between items-center pt-1 mt-1'> 
             <div className='flex flex-row items-center'>
-              {task.isGroupTask ? 
+              {task.isCompleted ? 
                 <>
-                  <UsersIcon className='w-5 h-5 text-gray-500 ml-2 lg:ml-4 mr-1' />
-                  <div className="text-gray-600 text-sm mr-3 lg:mr-5">{task.userName}</div>
+                  <CheckIcon className='w-5 h-5 ml-2 lg:ml-4 mr-1 text-gray-400' />
+                  <div className="text-gray-600 text-sm mr-3 lg:mr-5">{task.completedByName}</div>
                 </> 
               : 
-                <>
-                  <UserIcon className='w-5 h-5 text-gray-500 ml-2 lg:ml-4 mr-1' />
-                  <div className="text-gray-600 text-sm mr-3 lg:mr-5">{task.userName}</div>
-                </>  
-              }
+              <>
+                {task.isGroupTask ? 
+                  <div className='flex flex-col md:flex-row'>
+                    <div className='flex flex-row'>
+                      <MegaphoneIcon className='w-5 h-5 ml-2 lg:ml-4 mr-1 text-gray-400' />
+                      <div className="text-gray-600 text-sm">from</div>
+                    </div>
+                    <div className="text-gray-600 font-bold text-sm ml-8 md:ml-3">{task.userName}さん</div>
+                  </div>
+                :  
+                  <>
+                    <UserIcon className='w-5 h-5 ml-2 lg:ml-4 mr-1 text-gray-400' />
+                    <div className="text-gray-600 font-bold text-sm mr-3 lg:mr-5">{task.userName}</div>
+                  </>            
+                }
+              </>
+            }
             </div>
-            {editableTaskIds.includes(task.id) && (
+            {editableTaskIds.includes(task.id) && 
               <TaskActions task={task} setCurrentEditingTask={setCurrentEditingTask} open={open} close={close}/>
-            )}
+            }
           </div>
         </div>
       </div>

--- a/app/features/teamTask/components/TaskCard.tsx
+++ b/app/features/teamTask/components/TaskCard.tsx
@@ -1,0 +1,66 @@
+"use client"
+import { useState } from 'react';
+import { Task } from '@/types';
+import { formatDateLayoutMMDD } from '@/utils/dateUtils';
+import { Checkbox, Tooltip, Rating } from "@mantine/core"
+import { ClockIcon, UserIcon } from '@heroicons/react/24/outline';
+import { UsersIcon } from '@heroicons/react/24/solid';
+import TaskActions from './TaskActions';
+
+type TaskCardProps = {
+  task: Task;
+  editableTaskIds: number[];
+  setCurrentEditingTask: (task: Task) => void;
+  open: () => void;
+  close: () => void;
+}
+
+export default function TaskCard({ task, editableTaskIds, setCurrentEditingTask, open, close }: TaskCardProps) {
+  const [checked, setChecked] = useState(false);
+  return (
+    <>
+      <div className={`h-full flex items-center p-4 rounded-lg bg-white shadow-md border-4 
+                            ${task.isGroupTask ? 'border-blue-100' : 'border-orange-100'}`}
+      >
+        <div className='flex mr-4'>
+          <Tooltip label="DONE?" arrowOffset={50} arrowSize={5} withArrow>
+            <Checkbox
+              size='lg'
+              color="#93c5fd"
+              checked={checked}
+              onChange={(event) => setChecked(event.currentTarget.checked)}
+              className="shadow-md"
+              variant="outline"
+            />
+          </Tooltip>
+        </div>
+        <div className="flex-grow">
+          <div className="text-gray-600 text-md font-bold ml-2 lg:ml-4 mb-1">{task.title}</div>
+          <div className='flex flex-row items-center border-t pt-2'>
+            <ClockIcon className='w-5 h-5 text-gray-500 ml-2 lg:ml-4 mr-1' />
+            <div className="text-gray-600 text-sm mr-3 lg:mr-5">{formatDateLayoutMMDD(task.deadline)}</div>
+            <Rating size="sm" count={3} color="#93c5fd" value={task.importance} readOnly/>
+          </div>
+          <div className='flex flex-row justify-between items-center pt-1 mt-1'> 
+            <div className='flex flex-row items-center'>
+              {task.isGroupTask ? 
+                <>
+                  <UsersIcon className='w-5 h-5 text-gray-500 ml-2 lg:ml-4 mr-1' />
+                  <div className="text-gray-600 text-sm mr-3 lg:mr-5">{task.userName}</div>
+                </> 
+              : 
+                <>
+                  <UserIcon className='w-5 h-5 text-gray-500 ml-2 lg:ml-4 mr-1' />
+                  <div className="text-gray-600 text-sm mr-3 lg:mr-5">{task.userName}</div>
+                </>  
+              }
+            </div>
+            {editableTaskIds.includes(task.id) && (
+              <TaskActions task={task} setCurrentEditingTask={setCurrentEditingTask} open={open} close={close}/>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/features/teamTask/components/TaskIndex.tsx
+++ b/app/features/teamTask/components/TaskIndex.tsx
@@ -17,6 +17,11 @@ type IndexProps = {
 export default function TaskIndex({taskList, editableTaskIds}: IndexProps) {
   const [opened, { open, close }] = useDisclosure(false);
   const [currentEditingTask, setCurrentEditingTask] =  useState<Task | null>(null);
+  const [checked, setChecked] = useState(false);
+
+  const filteredTasks = checked
+  ? taskList.filter(task => task.isCompleted)
+  : taskList.filter(task => !task.isCompleted);
 
   const renderModalTitle = () => {
     return (
@@ -32,13 +37,13 @@ export default function TaskIndex({taskList, editableTaskIds}: IndexProps) {
   return (
     <>
       <div className="container py-4 mx-auto md:min-w-[600px]">
-        <div className='flex flex-row items-center my-3'>
+        <div className='flex flex-row items-center my-3 ml-2'>
           <CreateTask />
-          <SwithTask />
+          <SwithTask checked={checked} setChecked={setChecked}/>
         </div>
         <div className="flex flex-wrap">
-          {taskList.length > 0 ? (
-            taskList.map((task) =>(
+          {filteredTasks.length > 0 ? (
+            filteredTasks.map((task) =>(
               <div className="p-1 md:w-1/2 w-full" key={task.id}>
                 <TaskCard 
                   task={task} 
@@ -50,7 +55,7 @@ export default function TaskIndex({taskList, editableTaskIds}: IndexProps) {
               </div>
             ))
           ) : (
-            <div className="text-center text-gray-500 py-5">タスクが登録されていません</div>
+            <div className="text-center text-gray-500 py-5">タスクがありません</div>
           )}
         </div>
       </div>

--- a/app/features/teamTask/components/TaskIndex.tsx
+++ b/app/features/teamTask/components/TaskIndex.tsx
@@ -1,13 +1,13 @@
 "use client"
 import { useState } from 'react';
-import { useDisclosure } from '@mantine/hooks';
-import { ActionIcon, Checkbox, Tooltip, Rating,  Modal } from "@mantine/core"
-import { PencilSquareIcon, ClockIcon, UserIcon, TrashIcon, PencilIcon } from '@heroicons/react/24/outline';
-import { UsersIcon } from '@heroicons/react/24/solid';
-import CreateTask from './CreateTask';
-import { formatDateLayoutMMDD } from '@/utils/dateUtils';
 import { Task } from '@/types';
+import { useDisclosure } from '@mantine/hooks';
+import { Modal } from "@mantine/core"
+import { PencilIcon } from '@heroicons/react/24/outline';
+import CreateTask from './CreateTask';
 import InputForm from './InputForm';
+import TaskCard from './TaskCard';
+import SwithTask from './Switch';
 
 type IndexProps = {
   taskList: Task[];
@@ -15,92 +15,38 @@ type IndexProps = {
 }
 
 export default function TaskIndex({taskList, editableTaskIds}: IndexProps) {
-  const [checked, setChecked] = useState(false);
   const [opened, { open, close }] = useDisclosure(false);
   const [currentEditingTask, setCurrentEditingTask] =  useState<Task | null>(null);
 
-  const handleEditButtonClick = (task: Task) => {
-    setCurrentEditingTask(task);
-    open();
-  };
-
   const renderModalTitle = () => {
     return (
-      <>
-        <div className='flex flex-row items-start w-full pt-4 pr-22 mr-16 mb-1 text-md font-bold text-gray-600'>
-          <div className='flex w-full ml-2 items-center'>
-            <PencilIcon className="w-8 h-8 text-gray-500 mr-2" />
-            タスクを編集する
-          </div>
+      <div className='flex flex-row items-start w-full pt-4 pr-22 mr-16 mb-1 text-md font-bold text-gray-600'>
+        <div className='flex w-full ml-2 items-center'>
+          <PencilIcon className="w-8 h-8 text-gray-500 mr-2" />
+          タスクを編集する
         </div>
-      </>
+      </div>
     );
   };
 
   return (
     <>
       <div className="container py-4 mx-auto md:min-w-[600px]">
-        <CreateTask />
+        <div className='flex flex-row items-center my-3'>
+          <CreateTask />
+          <SwithTask />
+        </div>
         <div className="flex flex-wrap">
           {taskList.length > 0 ? (
             taskList.map((task) =>(
               <div className="p-1 md:w-1/2 w-full" key={task.id}>
-                <div className={`h-full flex items-center p-4 rounded-lg bg-white shadow-md border-4 
-                                    ${task.isGroupTask ? 'border-blue-100' : 'border-orange-100'}`}
-                >
-                  <div className='flex mr-4'>
-                    <Tooltip label="DONE?" arrowOffset={50} arrowSize={5} withArrow>
-                      <Checkbox
-                        size='lg'
-                        color="#93c5fd"
-                        checked={checked}
-                        onChange={(event) => setChecked(event.currentTarget.checked)}
-                        className="shadow-md"
-                        variant="outline"
-                      />
-                    </Tooltip>
-                  </div>
-                  <div className="flex-grow">
-                    <div className="text-gray-600 text-md font-bold ml-2 lg:ml-4 mb-1">{task.title}</div>
-                    <div className='flex flex-row items-center border-t pt-2'>
-                      <ClockIcon className='w-5 h-5 text-gray-500 ml-2 lg:ml-4 mr-1' />
-                      <div className="text-gray-600 text-sm mr-3 lg:mr-5">{formatDateLayoutMMDD(task.deadline)}</div>
-                      <Rating size="sm" count={3} color="#93c5fd" value={task.importance} readOnly/>
-                    </div>
-
-                    <div className='flex flex-row justify-between items-center pt-1 mt-1'> 
-                      <div className='flex flex-row items-center'>
-                        {task.isGroupTask ? 
-                          <>
-                            <UsersIcon className='w-5 h-5 text-gray-500 ml-2 lg:ml-4 mr-1' />
-                            <div className="text-gray-600 text-sm mr-3 lg:mr-5">{task.userName}</div>
-                          </> 
-                        : 
-                          <>
-                            <UserIcon className='w-5 h-5 text-gray-500 ml-2 lg:ml-4 mr-1' />
-                            <div className="text-gray-600 text-sm mr-3 lg:mr-5">{task.userName}</div>
-                          </>  
-                        }
-                      </div>
-                      {editableTaskIds.includes(task.id) && (
-                        <div className='flex pr-1 items-center'>
-                          <ActionIcon 
-                            variant="outline"
-                            color="#cbd5e1" 
-                            size="md" 
-                            className="shadow-md hover:text-gray-500 transition-transform"
-                            onClick={() => handleEditButtonClick(task)}
-                          >
-                            <PencilSquareIcon className='w-8 h-8 p-1' />
-                          </ActionIcon>
-                          <ActionIcon variant="outline" color="#cbd5e1" size="md" className="shadow-md hover:text-gray-500 transition-transform ml-2">
-                            <TrashIcon className='w-8 h-8 p-1' />
-                          </ActionIcon>
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                </div>
+                <TaskCard 
+                  task={task} 
+                  editableTaskIds={editableTaskIds} 
+                  setCurrentEditingTask={setCurrentEditingTask} 
+                  open={open} 
+                  close={close}
+                />
               </div>
             ))
           ) : (
@@ -122,7 +68,7 @@ export default function TaskIndex({taskList, editableTaskIds}: IndexProps) {
         >
           <div className="flex w-full px-6 py-4">
             <InputForm 
-              endpoint='editTask'
+              endpoint='updateTask'
               initialValues={{
                 title: currentEditingTask?.title ?? '',
                 isTeamTask: currentEditingTask?.isGroupTask ? "true" : "false",
@@ -130,7 +76,8 @@ export default function TaskIndex({taskList, editableTaskIds}: IndexProps) {
                 deadline: currentEditingTask ? new Date(currentEditingTask.deadline) : new Date(),
               }}
               taskId={currentEditingTask?.id}
-              close={close} 
+              close={close}
+              label="更新する"
             />
           </div>
         </Modal>

--- a/app/features/teamTask/components/TaskIndex.tsx
+++ b/app/features/teamTask/components/TaskIndex.tsx
@@ -1,230 +1,140 @@
 "use client"
 import { useState } from 'react';
-import { ActionIcon, Checkbox, Tooltip, Rating } from "@mantine/core"
-import { CheckIcon, TrashIcon, PencilSquareIcon, ClockIcon } from '@heroicons/react/24/outline';
-import UserStatus from "@/app/components/base/UserStatus"
-import DefaultUserImage from "@/app/components/ui/DefaultUserImage"
+import { useDisclosure } from '@mantine/hooks';
+import { ActionIcon, Checkbox, Tooltip, Rating,  Modal } from "@mantine/core"
+import { PencilSquareIcon, ClockIcon, UserIcon, TrashIcon, PencilIcon } from '@heroicons/react/24/outline';
+import { UsersIcon } from '@heroicons/react/24/solid';
+import CreateTask from './CreateTask';
+import { formatDateLayoutMMDD } from '@/utils/dateUtils';
+import { Task } from '@/types';
+import InputForm from './InputForm';
 
-export default function TaskIndex() {
+type IndexProps = {
+  taskList: Task[];
+  editableTaskIds: number[];
+}
+
+export default function TaskIndex({taskList, editableTaskIds}: IndexProps) {
   const [checked, setChecked] = useState(false);
-  const [value, setValue] = useState(0);
-  return (
-    <>
-        <div className="container py-4 mx-auto">
-          <div className="flex flex-wrap -m-2">
-            <div className="p-2 md:w-1/2 w-full">
-              <div className="h-full flex items-center p-4 rounded-lg bg-white shadow-md border-4 border-blue-100">
-                <UserStatus />
-                <div className="flex-grow">
-                  <h2 className="text-gray-600 font-bold ml-2 lg:ml-4">月末業務タスク</h2>
-                  <div className='flex flex-row items-center'>
-                    <ClockIcon className='w-5 h-5 text-gray-500 ml-2 lg:ml-4 mr-1' />
-                    <div className="text-gray-600 mr-3 lg:mr-5">12/30</div>
-                    <Rating defaultValue={2} size="sm" count={3} color="#93c5fd" value={value} onChange={setValue}/>
-                  </div>
-                </div>
-                <div className='flex ml-2'>
-                <Tooltip label="DONE?" arrowOffset={50} arrowSize={5} withArrow>
-                  <Checkbox
-                    size='lg'
-                    color="#93c5fd"
-                    checked={checked}
-                    onChange={(event) => setChecked(event.currentTarget.checked)}
-                    className="shadow-md"
-                    variant="outline"
-                  />
-                </Tooltip>
-                </div>
-                <div className='flex ml-2'>
-                  <ActionIcon variant="outline" color="#cbd5e1" size="md" className="shadow-md hover:text-gray-500 transition-transform">
-                    <PencilSquareIcon className='w-8 h-8 p-1' />
-                  </ActionIcon>
-                </div>
-              </div>
-            </div>
-            <div className="p-2 md:w-1/2 w-full">
-              <div className="h-full flex items-center p-4 rounded-lg bg-white shadow-md border-4 border-orange-100">
-                <UserStatus />
-                <div className="flex-grow">
-                  <h2 className="text-gray-600 font-bold ml-2 lg:ml-4">ストック整理</h2>
-                  <div className='flex flex-row items-center'>
-                    <ClockIcon className='w-5 h-5 text-gray-500 ml-2 lg:ml-4 mr-1' />
-                    <div className="text-red-400 mr-3 lg:mr-5">12/30</div>
-                    <Rating defaultValue={2} size="sm" count={3} color="#93c5fd" value={value} onChange={setValue}/>
-                  </div>
-                </div>
-                <div className='flex ml-2'>
-                <Tooltip label="DONE?" arrowOffset={50} arrowSize={5} withArrow>
-                  <Checkbox
-                    size='lg'
-                    color="#93c5fd"
-                    checked={checked}
-                    onChange={(event) => setChecked(event.currentTarget.checked)}
-                    className="shadow-md"
-                    variant="outline"
-                  />
-                </Tooltip>
-                </div>
-                <div className='flex ml-2'>
-                  <ActionIcon variant="outline" color="#cbd5e1" size="md" className="shadow-md hover:text-gray-500 transition-transform">
-                    <PencilSquareIcon className='w-8 h-8 p-1' />
-                  </ActionIcon>
-                </div>
-              </div>
-            </div>
-            <div className="p-2 md:w-1/2 w-full">
-              <div className="h-full flex items-center p-4 rounded-lg bg-white shadow-md">
-                <UserStatus />
-                <div className="flex-grow">
-                  <h2 className="text-gray-600 font-bold ml-2 lg:ml-4">倉庫整理</h2>
-                  <div className='flex flex-row items-center'>
-                    <ClockIcon className='w-5 h-5 text-gray-500 ml-2 lg:ml-4 mr-1' />
-                    <div className="text-red-400 mr-3 lg:mr-5">12/30</div>
-                    <Rating defaultValue={2} size="sm" count={3} color="#93c5fd" value={value} onChange={setValue}/>
-                  </div>
-                </div>
-                <div className='flex ml-2'>
-                <Tooltip label="DONE?" arrowOffset={50} arrowSize={5} withArrow>
-                  <Checkbox
-                    size='lg'
-                    color="#93c5fd"
-                    checked={checked}
-                    onChange={(event) => setChecked(event.currentTarget.checked)}
-                    className="shadow-md"
-                    variant="outline"
-                  />
-                </Tooltip>
-                </div>
-                <div className='flex ml-2'>
-                  <ActionIcon variant="outline" color="#cbd5e1" size="md" className="shadow-md hover:text-gray-500 transition-transform">
-                    <PencilSquareIcon className='w-8 h-8 p-1' />
-                  </ActionIcon>
-                </div>
-              </div>
-            </div>
-            <div className="p-2 md:w-1/2 w-full">
-              <div className="h-full flex items-center p-4 rounded-lg bg-white shadow-md">
-                <UserStatus />
-                <div className="flex-grow">
-                  <h2 className="text-gray-600 font-bold ml-2 lg:ml-4">スタイリング撮りだめ</h2>
-                  <div className='flex flex-row items-center'>
-                    <ClockIcon className='w-5 h-5 text-gray-500 ml-2 lg:ml-4 mr-1' />
-                    <div className="text-red-400 mr-3 lg:mr-5">12/30</div>
-                    <Rating defaultValue={2} size="sm" count={3} color="#93c5fd" value={value} onChange={setValue}/>
-                  </div>
-                </div>
-                <div className='flex ml-2'>
-                <Tooltip label="DONE?" arrowOffset={50} arrowSize={5} withArrow>
-                  <Checkbox
-                    size='lg'
-                    color="#93c5fd"
-                    checked={checked}
-                    onChange={(event) => setChecked(event.currentTarget.checked)}
-                    className="shadow-md"
-                    variant="outline"
-                  />
-                </Tooltip>
-                </div>
-                <div className='flex ml-2'>
-                  <ActionIcon variant="outline" color="#cbd5e1" size="md" className="shadow-md hover:text-gray-500 transition-transform">
-                    <PencilSquareIcon className='w-8 h-8 p-1' />
-                  </ActionIcon>
-                </div>
-              </div>
-            </div>
-            <div className="p-2 md:w-1/2 w-full">
-              <div className="h-full flex items-center p-4 rounded-lg bg-white shadow-md">
-                <UserStatus />
-                <div className="flex-grow">
-                  <h2 className="text-gray-600 font-bold ml-2 lg:ml-4">入力作業</h2>
-                  <div className='flex flex-row items-center'>
-                    <ClockIcon className='w-5 h-5 text-gray-500 ml-2 lg:ml-4 mr-1' />
-                    <div className="text-red-400 mr-3 lg:mr-5">12/30</div>
-                    <Rating defaultValue={2} size="sm" count={3} color="#93c5fd" value={value} onChange={setValue}/>
-                  </div>
-                </div>
-                <div className='flex ml-2'>
-                <Tooltip label="DONE?" arrowOffset={50} arrowSize={5} withArrow>
-                  <Checkbox
-                    size='lg'
-                    color="#93c5fd"
-                    checked={checked}
-                    onChange={(event) => setChecked(event.currentTarget.checked)}
-                    className="shadow-md"
-                    variant="outline"
-                  />
-                </Tooltip>
-                </div>
-                <div className='flex ml-2'>
-                  <ActionIcon variant="outline" color="#cbd5e1" size="md" className="shadow-md hover:text-gray-500 transition-transform">
-                    <PencilSquareIcon className='w-8 h-8 p-1' />
-                  </ActionIcon>
-                </div>
-              </div>
-            </div>
-            <div className="p-2 md:w-1/2 w-full">
-              <div className="h-full flex items-center p-4 rounded-lg bg-white shadow-md">
-                <UserStatus />
-                <div className="flex-grow">
-                  <h2 className="text-gray-600 font-bold ml-2 lg:ml-4">月末業務タスクだヨヨ</h2>
-                  <div className='flex flex-row items-center'>
-                    <ClockIcon className='w-5 h-5 text-gray-500 ml-2 lg:ml-4 mr-1' />
-                    <div className="text-red-400 mr-3 lg:mr-5">12/30</div>
-                    <Rating defaultValue={2} size="sm" count={3} color="#93c5fd" value={value} onChange={setValue}/>
-                  </div>
-                </div>
-                <div className='flex ml-2'>
-                <Tooltip label="DONE?" arrowOffset={50} arrowSize={5} withArrow>
-                  <Checkbox
-                    size='lg'
-                    color="#93c5fd"
-                    checked={checked}
-                    onChange={(event) => setChecked(event.currentTarget.checked)}
-                    className="shadow-md"
-                    variant="outline"
-                  />
-                </Tooltip>
-                </div>
-                <div className='flex ml-2'>
-                  <ActionIcon variant="outline" color="#cbd5e1" size="md" className="shadow-md hover:text-gray-500 transition-transform">
-                    <PencilSquareIcon className='w-8 h-8 p-1' />
-                  </ActionIcon>
-                </div>
-              </div>
-            </div>
-            <div className="p-2 md:w-1/2 w-full">
-              <div className="h-full flex items-center p-4 rounded-lg bg-white shadow-md">
-                <UserStatus />
-                <div className="flex-grow">
-                  <h2 className="text-gray-600 font-bold ml-2 lg:ml-4">月末業務タスクだヨヨ</h2>
-                  <div className='flex flex-row items-center'>
-                    <ClockIcon className='w-5 h-5 text-gray-500 ml-2 lg:ml-4 mr-1' />
-                    <div className="text-red-400 mr-3 lg:mr-5">12/30</div>
-                    <Rating defaultValue={2} size="sm" count={3} color="#93c5fd" value={value} onChange={setValue}/>
-                  </div>
-                </div>
-                <div className='flex ml-2'>
-                <Tooltip label="DONE?" arrowOffset={50} arrowSize={5} withArrow>
-                  <Checkbox
-                    size='xl'
-                    color="#93c5fd"
-                    checked={checked}
-                    onChange={(event) => setChecked(event.currentTarget.checked)}
-                    className="shadow-md"
-                    variant="outline"
-                  />
-                </Tooltip>
-                </div>
-                <div className='flex ml-2'>
-                  <ActionIcon variant="outline" color="#cbd5e1" size="lg" className="shadow-md hover:text-gray-500 transition-transform">
-                    <PencilSquareIcon className='w-8 h-8 p-1' />
-                  </ActionIcon>
-                </div>
-              </div>
-            </div>
+  const [opened, { open, close }] = useDisclosure(false);
+  const [currentEditingTask, setCurrentEditingTask] =  useState<Task | null>(null);
+
+  const handleEditButtonClick = (task: Task) => {
+    setCurrentEditingTask(task);
+    open();
+  };
+
+  const renderModalTitle = () => {
+    return (
+      <>
+        <div className='flex flex-row items-start w-full pt-4 pr-22 mr-16 mb-1 text-md font-bold text-gray-600'>
+          <div className='flex w-full ml-2 items-center'>
+            <PencilIcon className="w-8 h-8 text-gray-500 mr-2" />
+            タスクを編集する
           </div>
         </div>
+      </>
+    );
+  };
 
+  return (
+    <>
+      <div className="container py-4 mx-auto md:min-w-[600px]">
+        <CreateTask />
+        <div className="flex flex-wrap">
+          {taskList.length > 0 ? (
+            taskList.map((task) =>(
+              <div className="p-1 md:w-1/2 w-full" key={task.id}>
+                <div className={`h-full flex items-center p-4 rounded-lg bg-white shadow-md border-4 
+                                    ${task.isGroupTask ? 'border-blue-100' : 'border-orange-100'}`}
+                >
+                  <div className='flex mr-4'>
+                    <Tooltip label="DONE?" arrowOffset={50} arrowSize={5} withArrow>
+                      <Checkbox
+                        size='lg'
+                        color="#93c5fd"
+                        checked={checked}
+                        onChange={(event) => setChecked(event.currentTarget.checked)}
+                        className="shadow-md"
+                        variant="outline"
+                      />
+                    </Tooltip>
+                  </div>
+                  <div className="flex-grow">
+                    <div className="text-gray-600 text-md font-bold ml-2 lg:ml-4 mb-1">{task.title}</div>
+                    <div className='flex flex-row items-center border-t pt-2'>
+                      <ClockIcon className='w-5 h-5 text-gray-500 ml-2 lg:ml-4 mr-1' />
+                      <div className="text-gray-600 text-sm mr-3 lg:mr-5">{formatDateLayoutMMDD(task.deadline)}</div>
+                      <Rating size="sm" count={3} color="#93c5fd" value={task.importance} readOnly/>
+                    </div>
+
+                    <div className='flex flex-row justify-between items-center pt-1 mt-1'> 
+                      <div className='flex flex-row items-center'>
+                        {task.isGroupTask ? 
+                          <>
+                            <UsersIcon className='w-5 h-5 text-gray-500 ml-2 lg:ml-4 mr-1' />
+                            <div className="text-gray-600 text-sm mr-3 lg:mr-5">{task.userName}</div>
+                          </> 
+                        : 
+                          <>
+                            <UserIcon className='w-5 h-5 text-gray-500 ml-2 lg:ml-4 mr-1' />
+                            <div className="text-gray-600 text-sm mr-3 lg:mr-5">{task.userName}</div>
+                          </>  
+                        }
+                      </div>
+                      {editableTaskIds.includes(task.id) && (
+                        <div className='flex pr-1 items-center'>
+                          <ActionIcon 
+                            variant="outline"
+                            color="#cbd5e1" 
+                            size="md" 
+                            className="shadow-md hover:text-gray-500 transition-transform"
+                            onClick={() => handleEditButtonClick(task)}
+                          >
+                            <PencilSquareIcon className='w-8 h-8 p-1' />
+                          </ActionIcon>
+                          <ActionIcon variant="outline" color="#cbd5e1" size="md" className="shadow-md hover:text-gray-500 transition-transform ml-2">
+                            <TrashIcon className='w-8 h-8 p-1' />
+                          </ActionIcon>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="text-center text-gray-500 py-5">タスクが登録されていません</div>
+          )}
+        </div>
+      </div>
+
+      {opened && (
+        <Modal
+          opened={opened}
+          onClose={() => {
+            close();
+            setCurrentEditingTask(null);
+          }}
+          centered
+          size="md"
+          title={renderModalTitle()}
+        >
+          <div className="flex w-full px-6 py-4">
+            <InputForm 
+              endpoint='editTask'
+              initialValues={{
+                title: currentEditingTask?.title ?? '',
+                isTeamTask: currentEditingTask?.isGroupTask ? "true" : "false",
+                importance: currentEditingTask?.importance ?? 0,
+                deadline: currentEditingTask ? new Date(currentEditingTask.deadline) : new Date(),
+              }}
+              taskId={currentEditingTask?.id}
+              close={close} 
+            />
+          </div>
+        </Modal>
+      )}
     </>
   )
 }

--- a/app/features/teamTask/components/TaskTab.tsx
+++ b/app/features/teamTask/components/TaskTab.tsx
@@ -1,10 +1,15 @@
 "use client"
+import useTaskStore from '@/store/taskStore';
 import { Tabs } from '@mantine/core';
-import { TriangleIcon } from '../ui/icon/Triangle';
+import { TriangleIcon } from '../../../components/ui/icon/Triangle';
 import TaskIndex from '@/app/features/teamTask/components/TaskIndex';
 import { FolderIcon } from '@heroicons/react/24/outline';
 
-export default function TeamTask() {
+export default function TaskTab() {
+  const { teamTasks, userTasks } = useTaskStore();
+  const onlyTeamTasks = teamTasks.filter(task => task.isGroupTask);
+  const userTaskIds = userTasks.map(task => task.id);
+
   return (
     <div className="flex flex-col justify-center items-center mx-auto px-6 z-0 max-w-4xl mb-7 mt-4">
       <Tabs color="#93c5fd" defaultValue="all">
@@ -13,23 +18,23 @@ export default function TeamTask() {
             ALL
           </Tabs.Tab>
           <Tabs.Tab value="personal" leftSection={<TriangleIcon className="w-4 h-4 text-blue-300"/>}>
-            共有タスク
+            TEAM
           </Tabs.Tab>
           <Tabs.Tab value="share" leftSection={<TriangleIcon className="w-4 h-4 text-orange-300"/>} color="#fdba74">
-            個人タスク
+            MINE
           </Tabs.Tab>
         </Tabs.List>
 
         <Tabs.Panel value="all">
-          <TaskIndex />
+          <TaskIndex taskList={teamTasks} editableTaskIds={userTaskIds}/>
         </Tabs.Panel>
 
         <Tabs.Panel value="personal">
-          <TaskIndex />
+          <TaskIndex taskList={onlyTeamTasks} editableTaskIds={userTaskIds}/>
         </Tabs.Panel>
 
         <Tabs.Panel value="share">
-          <TaskIndex />
+          <TaskIndex taskList={userTasks} editableTaskIds={userTaskIds}/>
         </Tabs.Panel>
       </Tabs>
     </div>

--- a/app/features/teamTask/components/TaskTab.tsx
+++ b/app/features/teamTask/components/TaskTab.tsx
@@ -8,6 +8,7 @@ import { FolderIcon } from '@heroicons/react/24/outline';
 export default function TaskTab() {
   const { teamTasks, userTasks } = useTaskStore();
   const onlyTeamTasks = teamTasks.filter(task => task.isGroupTask);
+  const currentUserTasks = userTasks.filter(task => !task.isGroupTask)
   const userTaskIds = userTasks.map(task => task.id);
 
   return (
@@ -20,7 +21,7 @@ export default function TaskTab() {
           <Tabs.Tab value="personal" leftSection={<TriangleIcon className="w-4 h-4 text-blue-300"/>}>
             TEAM
           </Tabs.Tab>
-          <Tabs.Tab value="share" leftSection={<TriangleIcon className="w-4 h-4 text-orange-300"/>} color="#fdba74">
+          <Tabs.Tab value="share" leftSection={<TriangleIcon className="w-4 h-4 text-sky-700"/>} color="#0369a1">
             MINE
           </Tabs.Tab>
         </Tabs.List>
@@ -34,7 +35,7 @@ export default function TaskTab() {
         </Tabs.Panel>
 
         <Tabs.Panel value="share">
-          <TaskIndex taskList={userTasks} editableTaskIds={userTaskIds}/>
+          <TaskIndex taskList={currentUserTasks} editableTaskIds={userTaskIds}/>
         </Tabs.Panel>
       </Tabs>
     </div>

--- a/app/features/teamTask/hooks/fetchTask.ts
+++ b/app/features/teamTask/hooks/fetchTask.ts
@@ -2,11 +2,17 @@
 import { Task } from "@/types";
 import { showErrorNotification } from "@/utils/notifications";
 
-export const fetchTasks = async (setTasks: (tasks: Task[]) => void) => {
+type FetchTasksProps = {
+  setUserTasks: (tasks: Task[]) => void;
+  setTeamTasks:(tasks: Task[]) => void;
+}
+
+export const fetchTasks = async ({setUserTasks, setTeamTasks}: FetchTasksProps) => {
   try {
     const response = await fetch('/features/teamTask/api/getTasks');
     const data = await response.json();
-    setTasks(data)
+    setUserTasks(data.user_tasks);
+    setTeamTasks(data.group_tasks);
   } catch (error) {
     console.error(error);
     showErrorNotification('データの取得に失敗しました');

--- a/app/features/teamTask/hooks/fetchTask.ts
+++ b/app/features/teamTask/hooks/fetchTask.ts
@@ -1,0 +1,14 @@
+"use client"
+import { Task } from "@/types";
+import { showErrorNotification } from "@/utils/notifications";
+
+export const fetchTasks = async (setTasks: (tasks: Task[]) => void) => {
+  try {
+    const response = await fetch('/features/teamTask/api/getTasks');
+    const data = await response.json();
+    setTasks(data)
+  } catch (error) {
+    console.error(error);
+    showErrorNotification('データの取得に失敗しました');
+  }
+};

--- a/app/features/teamTask/hooks/useTeamTask.ts
+++ b/app/features/teamTask/hooks/useTeamTask.ts
@@ -1,0 +1,16 @@
+"use client"
+import { useEffect } from "react";
+import useTaskStore from "@/store/taskStore";
+import { fetchTasks } from "./fetchTask";
+
+const useFetchTask = () => {
+  const { teamTasks, setTeamTasks, userTasks, setUserTasks } = useTaskStore();
+
+  useEffect(() => {
+    if (teamTasks.length === 0) {
+      fetchTasks({setTeamTasks, setUserTasks});
+    }
+  }, [setTeamTasks, teamTasks, userTasks, setUserTasks]);
+};
+
+export default useFetchTask;

--- a/app/features/teamTask/hooks/useTeamTask.ts
+++ b/app/features/teamTask/hooks/useTeamTask.ts
@@ -7,10 +7,10 @@ const useFetchTask = () => {
   const { teamTasks, setTeamTasks, userTasks, setUserTasks } = useTaskStore();
 
   useEffect(() => {
-    if (teamTasks.length === 0) {
-      fetchTasks({setTeamTasks, setUserTasks});
+    if (teamTasks.length === 0 || userTasks.length === 0) {
+      fetchTasks({ setTeamTasks, setUserTasks });
     }
-  }, [setTeamTasks, teamTasks, userTasks, setUserTasks]);
+  },  [teamTasks.length, userTasks.length, setTeamTasks, setUserTasks]);
 };
 
 export default useFetchTask;

--- a/app/features/user/hooks/useUser.ts
+++ b/app/features/user/hooks/useUser.ts
@@ -4,17 +4,18 @@ import useUserStore from "@/store/userStore";
 import { showErrorNotification } from "@/utils/notifications";
 
 const useFetchUser = () => {
-  const { notifications, team} = useUserStore();
+  const { notifications, teamId, teamName} = useUserStore();
 
   useEffect(() => {
-    if (notifications === undefined || team === undefined) {
+    if (notifications === undefined || teamId === undefined || teamName === undefined) {
       const fetchUser = async () => {
         try {
           const response = await fetch(`/api/setting`);
           const data = await response.json();
           useUserStore.setState({
             notifications: data.notifications,
-            team: data.group_name
+            teamId: data.group_id,
+            teamName: data.group_name
           });
         } catch (error) {
           console.error(error);
@@ -23,7 +24,7 @@ const useFetchUser = () => {
       };
       fetchUser();
     }
-  }, [notifications, team]);
+  }, [notifications, teamId, teamName]);
 };
 
 export default useFetchUser;

--- a/store/taskStore.ts
+++ b/store/taskStore.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+import { Task } from '@/types';
+
+type TaskState = {
+  userTasks: Task[];
+  setUserTasks:(tasks: Task[]) => void;
+  teamTasks: Task[];
+  setTeamTasks: (tasks: Task[]) => void;
+};
+
+const useTaskStore = create<TaskState>((set) => ({
+  teamTasks: [],
+  setTeamTasks: (teamTasks) => set(() => ({ teamTasks })),
+  userTasks: [],
+  setUserTasks:(userTasks) => set(() => ({ userTasks })),
+}))
+
+export default useTaskStore;

--- a/store/userStore.ts
+++ b/store/userStore.ts
@@ -2,16 +2,18 @@ import { create } from 'zustand';
 
 type UserState = {
   notifications: boolean | undefined;
-  team: string | undefined;
+  teamId: number | undefined;
+  teamName: string | undefined;
   setNotifications: (force: boolean) => void;
   setTeam: (team: string) => void;
 };
 
 const useUserStore = create<UserState>((set, get) => ({
   notifications: undefined,
-  team: undefined,
+  teamId: undefined,
+  teamName: undefined,
   setNotifications: (notifications) => set(() => ({ notifications })),
-  setTeam: (team) => set(() => ({ team })),
+  setTeam: (teamName) => set(() => ({ teamName })),
 }))
 
 export default useUserStore;

--- a/types/index.ts
+++ b/types/index.ts
@@ -65,3 +65,14 @@ export type TeamInfo = {
   name: string;
   keyword: string;
 };
+
+export type Task = {
+  id: number;
+  title: string;
+  isGroupTask: boolean;
+  importance: number;
+  deadline: Date;
+  userId: number;
+  teamId: number;
+  userName: string;
+};

--- a/types/index.ts
+++ b/types/index.ts
@@ -75,4 +75,6 @@ export type Task = {
   userId: number;
   teamId: number;
   userName: string;
+  isCompleted: boolean;
+  completedByName: string | null;
 };

--- a/utils/dateUtils.ts
+++ b/utils/dateUtils.ts
@@ -16,6 +16,10 @@ export const formatDateLayout = (date :Date) => {
   return dayjs(date).format("YYYY / MM / DD   ( ddd )");
 };
 
+export const formatDateLayoutMMDD = (date :Date) => {
+  return dayjs(date).format("MM/DD");
+};
+
 export const getStartOfWeek = (date :Date) => {
   return dayjs(date).startOf('isoWeek').toDate();
 }


### PR DESCRIPTION
## 概要

チームタスク機能の実装

issue: #112 

## 変更点

- タスクの登録ができる(チームか個人かの選択, 優先度や期日の登録)
- タスクの編集、削除ができる(タスクの作成者のみ)
- タスクの完了ができる（チームタスクはメンバー全員, 個人タスクは作成者のみ）
- タブでカテゴリー毎に一覧表示の切り替え（所属チームの全タスク, 所属チームのチームタスク, 自分のタスク）
- スイッチで完了未完了毎に一覧の切り替え

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0

- ダミーユーザーを作成し一連の流れを確認

## 影響範囲
- dm_teams内で確認

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応