### PR TITLE
Team Top #115

### DIFF
--- a/app/(authenticated)/dm_team_task/layout.tsx
+++ b/app/(authenticated)/dm_team_task/layout.tsx
@@ -1,0 +1,15 @@
+import TeamHeader from "@/app/features/teamJoin/components/TeamHeader"
+
+export default function AuthenticatedLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+
+  return (
+    <>
+      <TeamHeader />
+      {children}
+    </>
+  )
+}

--- a/app/(authenticated)/dm_team_task/page.tsx
+++ b/app/(authenticated)/dm_team_task/page.tsx
@@ -1,4 +1,4 @@
-import Teams from "@/app/components/page/Teams"
+import TeamTasks from "@/app/components/page/TeamTasks"
 import { Metadata } from "next"
 
 export const metadata: Metadata = {
@@ -6,5 +6,5 @@ export const metadata: Metadata = {
 }
 
 export default function page() {
-  return <Teams/>
+  return <TeamTasks />
 }

--- a/app/components/page/TeamTasks.tsx
+++ b/app/components/page/TeamTasks.tsx
@@ -1,13 +1,12 @@
 "use client"
 import useFetchUser from "@/app/features/user/hooks/useUser";
 import useUserStore from "@/store/userStore";
-import TeamTask from "../../features/teamTask/components/TaskTab";
+import TaskTab from "@/app/features/teamTask/components/TaskTab";
 import TeamIntroduction from "./TeamIntroduction";
 import Loading from "../ui/Loading";
 import useFetchTask from "@/app/features/teamTask/hooks/useTeamTask";
 
 export default function Teams() {
-  useFetchUser();
   useFetchTask();
   const { teamId } = useUserStore();
 
@@ -18,7 +17,7 @@ export default function Teams() {
   return (
     <>
       <div className="flex flex-col justify-center items-center mx-auto px-6 z-0 max-w-4xl mb-7 mt-4">
-        {teamId === 1 ? <TeamIntroduction /> : <TeamTask /> }
+        {teamId === 1 ? <TeamIntroduction /> : <TaskTab /> }
       </div>
     </>
   )

--- a/app/features/teamJoin/api/getTeamMembers/route.ts
+++ b/app/features/teamJoin/api/getTeamMembers/route.ts
@@ -1,0 +1,35 @@
+import { getJwt } from '@/lib/getJwt';
+import { NextRequest } from 'next/server';
+import { fetchDataFromApi } from '@/lib/fetchDataFromApi';
+
+const endpoint = "groups";
+
+export async function GET(req: NextRequest) {
+  const { accessToken } = await getJwt(req);
+
+  if (!accessToken) {
+    return new Response(JSON.stringify({ error: '認証が必要です' }), {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  try {
+    const data = await fetchDataFromApi(endpoint, accessToken);
+    return new Response(JSON.stringify(data), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  } catch (error) {
+    return new Response(JSON.stringify({ error:'予期せぬエラーが発生しました' }), {
+      status: 500,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+}

--- a/app/features/teamJoin/components/MemberIcon.tsx
+++ b/app/features/teamJoin/components/MemberIcon.tsx
@@ -1,0 +1,27 @@
+"use client"
+import { HoverCard, Group } from '@mantine/core';
+import { UserIcon } from "@heroicons/react/24/solid";
+import UserImage from "@/app/components/ui/UserImage";
+
+type MemberIconProps = {
+  imageUrl: string;
+  userName: string;
+};
+
+export default function MemberIcon({imageUrl, userName}: MemberIconProps) {
+  return (
+    <Group justify="center">
+      <HoverCard shadow="md">
+        <HoverCard.Target>
+          <div><UserImage image={imageUrl} name={userName} /></div>
+        </HoverCard.Target>
+        <HoverCard.Dropdown>
+          <div className="flex flex-row items-center p-1">
+            <UserIcon className='w-5 h-5 mr-1 text-gray-400' />
+            <div className="text-gray-500">{userName}</div>
+          </div>
+        </HoverCard.Dropdown>
+      </HoverCard>
+    </Group> 
+  )
+}

--- a/app/features/teamJoin/components/MembersIcon.tsx
+++ b/app/features/teamJoin/components/MembersIcon.tsx
@@ -1,0 +1,42 @@
+"use client"
+import useTeamStore from "@/store/teamStore"
+import UserImage from "@/app/components/ui/UserImage";
+import Loading from "@/app/components/ui/Loading";
+import useFetchTeams from "@/app/features/teamJoin/hooks/useTeams";
+import useFetchUser from "@/app/features/user/hooks/useUser";
+import useUserStore from "@/store/userStore";
+import { MegaphoneIcon } from "@heroicons/react/24/outline";
+
+export default function MembersIcon() {
+  useFetchUser();
+  useFetchTeams();
+  const { teamId, teamName } = useUserStore();
+  const { members } = useTeamStore();
+
+  if (teamId === undefined) {
+    return <Loading size="xs"/>;
+  }
+
+  if (teamId === 1) {
+    return (
+      <div className="flex flex-row items-center">
+        <MegaphoneIcon className='w-6 h-6 lg:ml-5 mr-2 text-gray-400' />
+        <div className="text-md">チームに所属していません。</div>
+      </div>
+    ) 
+  }
+
+  return (
+    <div className="flex flex-row items-center">
+      <div className="mr-2 lg:ml-5 font-bold pr-3 border-r-2 border-gray-200">{teamName}</div>
+      {members && members.map((member) => (
+        <div key={member.id} className="mr-1">
+          <UserImage 
+            image={member.imageUrl} 
+            name={member.name} 
+          />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/app/features/teamJoin/components/TeamHeader.tsx
+++ b/app/features/teamJoin/components/TeamHeader.tsx
@@ -1,0 +1,13 @@
+import MembersIcon from "./MembersIcon";
+
+export default function TeamHeader() {
+  return (
+    <div className="text-gray-600 body-font bg-gray-50 items-center md:pb-0">
+      <div className="container mx-auto flex flex-wrap p-4 items-center md:max-w-2xl lg:max-w-4xl">
+        <div className="flex flex-row items-center px-6 z-0 max-w-4xl">
+          <MembersIcon/>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/features/teamJoin/components/TeamHeader.tsx
+++ b/app/features/teamJoin/components/TeamHeader.tsx
@@ -1,11 +1,11 @@
-import MembersIcon from "./MembersIcon";
+import TeamMembers from "./TeamMembers";
 
 export default function TeamHeader() {
   return (
     <div className="text-gray-600 body-font bg-gray-50 items-center md:pb-0">
       <div className="container mx-auto flex flex-wrap p-4 items-center md:max-w-2xl lg:max-w-4xl">
         <div className="flex flex-row items-center px-6 z-0 max-w-4xl">
-          <MembersIcon/>
+          <TeamMembers/>
         </div>
       </div>
     </div>

--- a/app/features/teamJoin/components/TeamMembers.tsx
+++ b/app/features/teamJoin/components/TeamMembers.tsx
@@ -1,13 +1,13 @@
 "use client"
 import useTeamStore from "@/store/teamStore"
-import UserImage from "@/app/components/ui/UserImage";
 import Loading from "@/app/components/ui/Loading";
 import useFetchTeams from "@/app/features/teamJoin/hooks/useTeams";
 import useFetchUser from "@/app/features/user/hooks/useUser";
 import useUserStore from "@/store/userStore";
 import { MegaphoneIcon } from "@heroicons/react/24/outline";
+import MemberIcon from "./MemberIcon";
 
-export default function MembersIcon() {
+export default function TeamMembers() {
   useFetchUser();
   useFetchTeams();
   const { teamId, teamName } = useUserStore();
@@ -31,10 +31,7 @@ export default function MembersIcon() {
       <div className="mr-2 lg:ml-5 font-bold pr-3 border-r-2 border-gray-200">{teamName}</div>
       {members && members.map((member) => (
         <div key={member.id} className="mr-1">
-          <UserImage 
-            image={member.imageUrl} 
-            name={member.name} 
-          />
+          <MemberIcon imageUrl={member.imageUrl} userName={member.name} />
         </div>
       ))}
     </div>

--- a/app/features/teamJoin/hooks/useTeams.ts
+++ b/app/features/teamJoin/hooks/useTeams.ts
@@ -1,0 +1,28 @@
+"use client"
+import { useEffect } from "react";
+import useTeamStore from "@/store/teamStore";
+import useUserStore from "@/store/userStore";
+import { showErrorNotification } from "@/utils/notifications";
+
+const useFetchTeams = () => {
+  const { members, setMembers } = useTeamStore();
+  const { teamId } = useUserStore();
+
+  useEffect(() => {
+    if (teamId !== 1 && (members?.length === 0 || !members)) {
+    const fetchTeams = async () => {
+        try {
+          const response = await fetch(`/features/teamJoin/api/getTeamMembers`);
+          const data = await response.json();
+          setMembers(data.members)
+        } catch (error) {
+          console.error(error);
+          showErrorNotification('データの取得に失敗しました');
+        }
+    }
+    fetchTeams();
+  }
+  }, [members?.length, teamId, setMembers]);
+};
+
+export default useFetchTeams;

--- a/app/features/teamJoin/hooks/useTeams.ts
+++ b/app/features/teamJoin/hooks/useTeams.ts
@@ -10,7 +10,7 @@ const useFetchTeams = () => {
 
   useEffect(() => {
     if (teamId !== 1 && (members?.length === 0 || !members)) {
-    const fetchTeams = async () => {
+      const fetchTeams = async () => {
         try {
           const response = await fetch(`/features/teamJoin/api/getTeamMembers`);
           const data = await response.json();
@@ -19,10 +19,10 @@ const useFetchTeams = () => {
           console.error(error);
           showErrorNotification('データの取得に失敗しました');
         }
+      }
+      fetchTeams();
     }
-    fetchTeams();
-  }
-  }, [members?.length, teamId, setMembers]);
+  }, [members, teamId, setMembers]);
 };
 
 export default useFetchTeams;

--- a/app/features/teamTask/components/FormLabel.tsx
+++ b/app/features/teamTask/components/FormLabel.tsx
@@ -1,0 +1,24 @@
+import { TriangleIcon } from '@/app/components/ui/icon/Triangle';
+
+type FormLabelProps = {
+  children: string;
+}
+
+export function FormLabel({children}: FormLabelProps) {
+  return (
+    <div className="flex flex-row items-center">
+      <TriangleIcon className="w-4 h-4 mr-2 mb-1 text-sky-800" />
+      <div className='text-gray-800'>{children}</div>
+    </div>
+  )
+}
+
+export function FormLabelAsterisk({children}: FormLabelProps) {
+  return (
+    <div className="flex flex-row items-center">
+      <TriangleIcon className="w-4 h-4 mr-2 mb-1 text-sky-800" />
+      <div className='text-gray-800'>{children}</div>
+      <div className='text-xs text-red-400 ml-1'>＊</div>
+    </div>
+  )
+}

--- a/app/features/teamTask/components/InputForm.tsx
+++ b/app/features/teamTask/components/InputForm.tsx
@@ -10,8 +10,8 @@ import { formatDate } from '@/utils/dateUtils';
 import { useForm } from '@mantine/form';
 import { DatePickerInput } from '@mantine/dates';
 import { TextInput, Radio, Group, Rating } from "@mantine/core"
-import { TriangleIcon } from '@/app/components/ui/icon/Triangle';
 import PlusButton from '@/app/components/ui/button/PlusButton';
+import { FormLabelAsterisk, FormLabel } from './FormLabel';
 
 type InputFormProps = {
   endpoint: string;
@@ -74,14 +74,10 @@ export default function InputForm({endpoint, initialValues, taskId, close, label
   };
     
   return (
-    <>
-      <div className="flex flex-col justify-center items-center w-full">
-        <form onSubmit={form.onSubmit(handleSubmit)} className='w-full'>
-          <div className="flex flex-row items-center">
-            <TriangleIcon className="w-4 h-4 mr-2 mb-1 text-sky-800" />
-          <div className='text-gray-800'>タスクの種類</div>
-          <div className='text-xs text-red-400 ml-1'>＊</div>
-        </div>
+    <div className="flex flex-col justify-center items-center w-full">
+      <form onSubmit={form.onSubmit(handleSubmit)} className='w-full'>
+
+        <FormLabelAsterisk>タスクの種類</FormLabelAsterisk>
         <Radio.Group
           {...form.getInputProps('isTeamTask')}
           name="isTeamTask"
@@ -93,11 +89,7 @@ export default function InputForm({endpoint, initialValues, taskId, close, label
           </Group>
         </Radio.Group>
 
-        <div className="flex flex-row items-center">
-          <TriangleIcon className="w-4 h-4 mr-2 mb-1 text-sky-800" />
-          <div className='text-gray-800'>タスク名</div>
-          <div className='text-xs text-red-400 ml-1'>＊</div>
-        </div>
+        <FormLabelAsterisk>タスク名</FormLabelAsterisk>
         <TextInput
           {...form.getInputProps('title')}
           name="title" 
@@ -106,17 +98,10 @@ export default function InputForm({endpoint, initialValues, taskId, close, label
           className='mb-5'
         />
 
-        <div className="flex flex-row items-center">
-          <TriangleIcon className="w-4 h-4 mr-2 mb-1 text-sky-800" />
-          <div className='text-gray-800'>優先度</div>
-        </div>
+        <FormLabel>優先度</FormLabel>
         <Rating count={3} size="lg" className='mt-2 mb-5' {...form.getInputProps('importance')}/>
 
-        <div className="flex flex-row items-center">
-          <TriangleIcon className="w-4 h-4 mr-2 mb-1 text-sky-800" />
-          <div className='text-gray-800'>期限</div>
-          <div className='text-xs text-red-400 ml-1'>＊</div>
-        </div>
+        <FormLabelAsterisk>期限</FormLabelAsterisk>
         <DatePickerInput
           {...form.getInputProps('deadline')}
           placeholder="完了したい日付の選択"
@@ -128,6 +113,5 @@ export default function InputForm({endpoint, initialValues, taskId, close, label
         </div>
       </form>
     </div>
-  </>
   )
 }

--- a/app/features/teamTask/components/TaskCard.tsx
+++ b/app/features/teamTask/components/TaskCard.tsx
@@ -1,14 +1,14 @@
 "use client"
-import axios from 'axios'
 import { useState } from 'react';
+import axios from 'axios'
 import { Task } from '@/types';
-import { formatDateLayoutMMDD } from '@/utils/dateUtils';
+import useTaskStore from '@/store/taskStore';
+import { formatDateLayoutMMDD, isDeadlineSoon } from '@/utils/dateUtils';
+import { showSuccessNotification, showErrorNotification } from '@/utils/notifications';
 import { Checkbox, Tooltip, Rating } from "@mantine/core"
 import { CheckIcon, ClockIcon, MegaphoneIcon, UserIcon } from '@heroicons/react/24/outline';
 import TaskActions from './TaskActions';
-import { showSuccessNotification, showErrorNotification } from '@/utils/notifications';
 import { fetchTasks } from '../hooks/fetchTask';
-import useTaskStore from '@/store/taskStore';
 
 type TaskCardProps = {
   task: Task;
@@ -72,7 +72,11 @@ export default function TaskCard({ task, editableTaskIds, setCurrentEditingTask,
           <div className="text-gray-600 text-md font-bold ml-2 lg:ml-4 mb-1">{task.title}</div>
           <div className='flex flex-row items-center border-t pt-2'>
             <ClockIcon className='w-5 h-5 text-gray-500 ml-2 lg:ml-4 mr-1' />
-            <div className="text-gray-600 text-sm mr-3 lg:mr-5">{formatDateLayoutMMDD(task.deadline)}</div>
+            {isDeadlineSoon(task.deadline) ? 
+              <div className="text-red-400 text-sm mr-3 lg:mr-5">{formatDateLayoutMMDD(task.deadline)}</div>
+            :
+              <div className="text-gray-600 text-sm mr-3 lg:mr-5">{formatDateLayoutMMDD(task.deadline)}</div>
+            }
             <Rating size="sm" count={3} color={taskColorClass} value={task.importance} readOnly/>
           </div>
           <div className='flex flex-row justify-between items-center pt-1 mt-1'> 

--- a/app/features/teamTask/components/TaskCard.tsx
+++ b/app/features/teamTask/components/TaskCard.tsx
@@ -6,9 +6,10 @@ import useTaskStore from '@/store/taskStore';
 import { formatDateLayoutMMDD, isDeadlineSoon } from '@/utils/dateUtils';
 import { showSuccessNotification, showErrorNotification } from '@/utils/notifications';
 import { Checkbox, Tooltip, Rating } from "@mantine/core"
-import { CheckIcon, ClockIcon, MegaphoneIcon, UserIcon } from '@heroicons/react/24/outline';
-import TaskActions from './TaskActions';
+import { CheckIcon, ClockIcon } from '@heroicons/react/24/outline';
 import { fetchTasks } from '../hooks/fetchTask';
+import TaskActions from './TaskActions';
+import MemberIcon from '../../teamJoin/components/MemberIcon';
 
 type TaskCardProps = {
   task: Task;
@@ -69,9 +70,10 @@ export default function TaskCard({ task, editableTaskIds, setCurrentEditingTask,
           </Tooltip>
         </div>
         <div className="flex-grow">
-          <div className="text-gray-600 text-md font-bold ml-2 lg:ml-4 mb-1">{task.title}</div>
-          <div className='flex flex-row items-center border-t pt-2'>
-            <ClockIcon className='w-5 h-5 text-gray-500 ml-2 lg:ml-4 mr-1' />
+          <div className="text-gray-600 text-md font-bold ml-2 lg:ml-4 mb-2">{task.title}</div>
+          <div className='flex flex-row items-center border-t pt-3'>
+            <MemberIcon imageUrl={task.userImageUrl} userName={task.userName}/>
+            <ClockIcon className='w-5 h-5 text-gray-500 ml-3 mr-1' />
             {isDeadlineSoon(task.deadline) ? 
               <div className="text-red-400 text-sm mr-3 lg:mr-5">{formatDateLayoutMMDD(task.deadline)}</div>
             :
@@ -79,31 +81,15 @@ export default function TaskCard({ task, editableTaskIds, setCurrentEditingTask,
             }
             <Rating size="sm" count={3} color={taskColorClass} value={task.importance} readOnly/>
           </div>
-          <div className='flex flex-row justify-between items-center pt-1 mt-1'> 
+
+          <div className='flex flex-row justify-end items-center pt-1 mt-1'> 
             <div className='flex flex-row items-center'>
-              {task.isCompleted ? 
+              {task.isCompleted && 
                 <>
                   <CheckIcon className='w-5 h-5 ml-2 lg:ml-4 mr-1 text-gray-400' />
                   <div className="text-gray-600 text-sm mr-3 lg:mr-5">{task.completedByName}</div>
                 </> 
-              : 
-              <>
-                {task.isGroupTask ? 
-                  <div className='flex flex-col md:flex-row'>
-                    <div className='flex flex-row'>
-                      <MegaphoneIcon className='w-5 h-5 ml-2 lg:ml-4 mr-1 text-gray-400' />
-                      <div className="text-gray-600 text-sm">from</div>
-                    </div>
-                    <div className="text-gray-600 font-bold text-sm ml-8 md:ml-3">{task.userName}さん</div>
-                  </div>
-                :  
-                  <>
-                    <UserIcon className='w-5 h-5 ml-2 lg:ml-4 mr-1 text-gray-400' />
-                    <div className="text-gray-600 font-bold text-sm mr-3 lg:mr-5">{task.userName}</div>
-                  </>            
-                }
-              </>
-            }
+              }
             </div>
             {editableTaskIds.includes(task.id) && 
               <TaskActions task={task} setCurrentEditingTask={setCurrentEditingTask} open={open} close={close}/>

--- a/lib/options.ts
+++ b/lib/options.ts
@@ -28,6 +28,7 @@ export const options : NextAuthOptions = {
 			  "user": {
 				"line_id": account.providerAccountId,
 				"name": user.name,
+				"image_url": user.image,
 			  }
 			},
 			{

--- a/store/teamStore.ts
+++ b/store/teamStore.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+import { Member } from '@/types';
+
+type TeamState = {
+  members: Member[];
+  setMembers: (members: Member[]) => void;
+}
+
+const useTeamStore = create<TeamState>(set => ({
+  members: [],
+  setMembers: (members) => set({ members }),
+}));
+
+export default useTeamStore;

--- a/types/index.ts
+++ b/types/index.ts
@@ -78,3 +78,9 @@ export type Task = {
   isCompleted: boolean;
   completedByName: string | null;
 };
+
+export type Member = {
+  id: number;
+  name: string;
+  imageUrl: string;
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -75,6 +75,7 @@ export type Task = {
   userId: number;
   teamId: number;
   userName: string;
+  userImageUrl: string;
   isCompleted: boolean;
   completedByName: string | null;
 };

--- a/utils/dateUtils.ts
+++ b/utils/dateUtils.ts
@@ -61,6 +61,12 @@ export const getThisWeekRange = () => {
   return { start, end };
 };
 
+export const isDeadlineSoon = (date: Date) => {
+  const deadlineDate = dayjs(date);
+  const today = dayjs();
+  return deadlineDate.diff(today, 'day') <= 3;
+};
+
 // string型で受け取る
 export const getWeekHead = (date :string) => {
   return dayjs(date).startOf('isoWeek').format('YYYY-MM-DD');


### PR DESCRIPTION
## 概要

チーム機能共通のUI作成
タスクカードのUIアップデート

issue: #115 

## 変更点

- LINEログイン時コールバックにプロフィール画像の送信を追加
- 画像を使ったチームメンバーの表示, タスクの表示にアップデート

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0
- バックエンドと期待するデータの受け渡しができる
- 受け取ったURLからメンバーをアイコン表示できる

## 影響範囲
- /dm_team_taskで確認

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応
