### PR TITLE
Task Fix & Update #127

### DIFF
--- a/app/features/demoPage/components/DemoSetting.tsx
+++ b/app/features/demoPage/components/DemoSetting.tsx
@@ -44,7 +44,14 @@ export default function DemoSetting() {
             </a>
           </div>
           <div className="flex py-5 pl-4">
-            <AlertSelect handleUpdate={handleUpdate} checked={checked} setChecked={setChecked}/>
+            <AlertSelect 
+              handleUpdate={handleUpdate} 
+              checked={checked} 
+              setChecked={setChecked}
+              labelTitle="週間レポート登録をリマインド"
+              description="毎週日曜日にお知らせします"
+              groupName='reportAlert'
+            />
           </div>
         </div>
       </div>  

--- a/app/features/teamJoin/components/CopyInfo.tsx
+++ b/app/features/teamJoin/components/CopyInfo.tsx
@@ -1,8 +1,11 @@
 "use client"
 import Link from "next/link";
 import Image from "next/image"
+import { useRouter } from 'next/navigation'
 import LineIcon from "@/public/btn_base.png";
 import { TeamInfo } from "@/types";
+import useUserStore from "@/store/userStore";
+import { fetchUser } from "../../user/hooks/fetchUser";
 import { UserGroupIcon, KeyIcon, CursorArrowRaysIcon } from '@heroicons/react/24/solid';
 import CopyActionButton from "@/app/components/ui/CopyActionButton";
 import createCopyText from "@/utils/createCopyText";
@@ -12,9 +15,12 @@ type CopyProps = {
 }
 
 export default function CopyInfo({TeamInfo}: CopyProps) {
+  const { setId, setTeamId, setTeamName, setNotifications} = useUserStore();
+  const router = useRouter();
 
   const handleClick = () => {
-    window.location.reload();
+    fetchUser({setId, setTeamId, setTeamName, setNotifications})
+    router.push('/team/task')
   }
 
   return (

--- a/app/features/teamJoin/components/CopyInfo.tsx
+++ b/app/features/teamJoin/components/CopyInfo.tsx
@@ -15,11 +15,11 @@ type CopyProps = {
 }
 
 export default function CopyInfo({TeamInfo}: CopyProps) {
-  const { setId, setTeamId, setTeamName, setNotifications} = useUserStore();
+  const { setId, setTeamId, setTeamName, setNotifications, setTaskNotifications} = useUserStore();
   const router = useRouter();
 
   const handleClick = () => {
-    fetchUser({setId, setTeamId, setTeamName, setNotifications})
+    fetchUser({setId, setTeamId, setTeamName, setNotifications, setTaskNotifications})
     router.push('/team/task')
   }
 

--- a/app/features/teamJoin/components/Form.tsx
+++ b/app/features/teamJoin/components/Form.tsx
@@ -105,7 +105,7 @@ export default function Form({apiEndpoint, buttonLabel, isCreatingGroup, isCreat
               name="keyword" 
               label={keywordLabel()}
               placeholder="例：sample123"
-              description="半角英数1~20文字で入力してください"
+              description="半角英数8~20文字で入力してください"
               visibilityToggleIcon={({ reveal }) =>
                 reveal ? (
                   <EyeSlashIcon style={{ width: 'var(--psi-icon-size)', height: 'var(--psi-icon-size)' }} />

--- a/app/features/teamTask/components/TaskActions.tsx
+++ b/app/features/teamTask/components/TaskActions.tsx
@@ -28,9 +28,8 @@ export default function TaskActions({ task, setCurrentEditingTask, open, close }
     }
     try {
       await axios.delete(`/features/teamTask/api/deleteTask/${taskId}`);
-      showSuccessNotification(`削除しました`);
       fetchTasks({setTeamTasks, setUserTasks});
-      close();
+      showSuccessNotification(`削除しました`);
     } catch (error) {
       showErrorNotification('削除に失敗しました。');
     }

--- a/app/features/teamTask/components/TaskHelpPage.tsx
+++ b/app/features/teamTask/components/TaskHelpPage.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link"
+import { CheckBadgeIcon } from "@heroicons/react/24/outline"
+
+export default function TaskHelpPage() {
+  return (
+    <div className="p-2">
+      <div className="flex items-center text-gray-700 underline pt-2">
+        <CheckBadgeIcon className="w-6 h-6 text-blue-300 mr-2 font-bold" />
+        タスクについて
+      </div>
+      <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
+        <p>左側のボタンから追加できます。</p>
+        <p>店舗単位で行うタスクなのか、個人タスクなのか選択してください</p>
+      </div> 
+        
+      <div className="flex items-center text-gray-700 underline border-t pt-2">
+        <CheckBadgeIcon className="w-6 h-6 text-blue-300 mr-2 font-bold" />
+        タスク一覧について
+      </div>
+      <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
+        <p className="mb-1">ページ上部のタブ左側から、</p>
+        <p> - メンバーが登録した全てのタスク</p>
+        <p> - メンバーが登録したチームタスク</p>
+        <p className="mb-1"> - 自分が登録したタスク</p>
+        <p>がそれぞれ表示されます。</p>
+      </div>
+
+      <div className="flex items-center text-gray-700 border-t underline pt-2">
+        <CheckBadgeIcon className="w-6 h-6 text-blue-300 mr-2 font-bold" />
+        タスクの通知機能について
+      </div>
+      <div className="py-1 ml-8 text-sm text-gray-700 pb-2">
+        <p>メンバーによってチームタスクが登録されるとLINEで通知が届きます。</p>
+        <Link href='/setting' className="text-sky-800 underline font-bold">こちらから</Link>
+        <span>通知の設定を行ってください。</span>
+      </div>         
+    </div>
+  )
+}

--- a/app/features/teamTask/components/TaskIndex.tsx
+++ b/app/features/teamTask/components/TaskIndex.tsx
@@ -80,7 +80,7 @@ export default function TaskIndex({taskList, editableTaskIds}: IndexProps) {
             close={close}
           />
         </div>
-        <Pagination total={chunkedTasks.length} value={activePage} onChange={setActivePage} mt="sm" color="#60a5fa" />
+        <Pagination total={chunkedTasks.length} value={activePage} onChange={setActivePage} mt="sm"/>
       </div>
 
       {opened && (

--- a/app/features/teamTask/components/TaskIndex.tsx
+++ b/app/features/teamTask/components/TaskIndex.tsx
@@ -9,6 +9,8 @@ import InputForm from './InputForm';
 import SwithTask from './Switch';
 import TaskForPc from './TaskForPc';
 import TaskForMb from './TaskForMb';
+import HelpMordal from '@/app/components/ui/HelpMordal';
+import TaskHelpPage from './TaskHelpPage';
 
 type IndexProps = {
   taskList: Task[];
@@ -55,6 +57,7 @@ export default function TaskIndex({taskList, editableTaskIds}: IndexProps) {
           <CreateTask />
           <div className='flex flex-row items-center'>
             <SwithTask checked={checked} setChecked={setChecked}/>
+            <HelpMordal><TaskHelpPage/></HelpMordal>
           </div>
         </div>
         <div className='hidden md:block'>

--- a/app/features/user/api/updateTaskNotification/route.ts
+++ b/app/features/user/api/updateTaskNotification/route.ts
@@ -1,0 +1,45 @@
+import axios from 'axios';
+import { NextRequest } from 'next/server';
+import { getJwt } from '@/lib/getJwt';
+
+export async function PATCH(req: NextRequest) {
+  const { accessToken } = await getJwt(req);
+
+  if (!accessToken) {
+    return new Response(JSON.stringify({ error: '認証が必要です' }), {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  const data = await req.json();
+  const user = data.user;
+  const apiUrl = process.env.RAILS_API_URL
+
+  try {
+    const response = await axios.patch(`${apiUrl}/users/update_task_notifications`, { 
+      user
+    }, {
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      }
+    });
+    return new Response(JSON.stringify(response.data), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  } catch (error) {
+    console.error(error); 
+    return new Response(JSON.stringify({ error: '予期せぬエラーが発生しました'  }), {
+      status: 500,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+}

--- a/app/features/user/hooks/fetchUser.ts
+++ b/app/features/user/hooks/fetchUser.ts
@@ -1,0 +1,23 @@
+"use client"
+import { showErrorNotification } from "@/utils/notifications";
+
+type FetchUserProps = {
+  setId: (id: number) => void;
+  setNotifications: (force: boolean) => void;
+  setTeamId: (teamId: number) => void;
+  setTeamName: (teamName: string) => void;
+}
+
+export  const fetchUser = async ({setId, setNotifications, setTeamId,  setTeamName}: FetchUserProps) => {
+  try {
+    const response = await fetch('/features/user/api/getCurrentSetting');
+    const data = await response.json();
+    setId(data.id)
+    setNotifications(data.notifications)
+    setTeamId(data.group_id)
+    setTeamName(data.group_name)
+  } catch (error) {
+    console.error(error);
+    showErrorNotification('データの取得に失敗しました');
+  }
+};

--- a/app/features/user/hooks/fetchUser.ts
+++ b/app/features/user/hooks/fetchUser.ts
@@ -4,16 +4,18 @@ import { showErrorNotification } from "@/utils/notifications";
 type FetchUserProps = {
   setId: (id: number) => void;
   setNotifications: (force: boolean) => void;
+  setTaskNotifications: (force: boolean) => void;
   setTeamId: (teamId: number) => void;
   setTeamName: (teamName: string) => void;
 }
 
-export  const fetchUser = async ({setId, setNotifications, setTeamId,  setTeamName}: FetchUserProps) => {
+export  const fetchUser = async ({setId, setNotifications, setTaskNotifications, setTeamId,  setTeamName}: FetchUserProps) => {
   try {
     const response = await fetch('/features/user/api/getCurrentSetting');
     const data = await response.json();
     setId(data.id)
     setNotifications(data.notifications)
+    setTaskNotifications(data.task_notifications)
     setTeamId(data.group_id)
     setTeamName(data.group_name)
   } catch (error) {

--- a/app/features/user/hooks/useUser.ts
+++ b/app/features/user/hooks/useUser.ts
@@ -4,13 +4,13 @@ import useUserStore from "@/store/userStore";
 import { fetchUser } from "./fetchUser";
 
 const useFetchUser = () => {
-  const { id, notifications, teamId, teamName, setId, setTeamId, setTeamName, setNotifications} = useUserStore();
+  const { id, notifications, teamId, teamName, taskNotifications, setId, setTeamId, setTeamName, setNotifications, setTaskNotifications} = useUserStore();
 
   useEffect(() => {
     if (notifications === undefined || teamId === undefined || teamName === undefined) {
-      fetchUser({setId, setTeamId, setTeamName, setNotifications});
+      fetchUser({setId, setTeamId, setTeamName, setNotifications, setTaskNotifications});
     }
-  }, [id, notifications, teamId, teamName, setId, setTeamId, setNotifications, setTeamName]);
+  }, [id, notifications, teamId, teamName, taskNotifications ,setId, setTeamId, setNotifications, setTeamName, setTaskNotifications]);
 };
 
 export default useFetchUser;

--- a/app/features/user/hooks/useUser.ts
+++ b/app/features/user/hooks/useUser.ts
@@ -1,27 +1,14 @@
 "use client"
 import { useEffect } from "react";
 import useUserStore from "@/store/userStore";
-import { showErrorNotification } from "@/utils/notifications";
+import { fetchUser } from "./fetchUser";
 
 const useFetchUser = () => {
   const { id, notifications, teamId, teamName, setId, setTeamId, setTeamName, setNotifications} = useUserStore();
 
   useEffect(() => {
     if (notifications === undefined || teamId === undefined || teamName === undefined) {
-      const fetchUser = async () => {
-        try {
-          const response = await fetch('/features/user/api/getCurrentSetting');
-          const data = await response.json();
-          setId(data.id)
-          setNotifications(data.notifications)
-          setTeamId(data.group_id)
-          setTeamName(data.group_name)
-        } catch (error) {
-          console.error(error);
-          showErrorNotification('データの取得に失敗しました');
-        }
-      };
-      fetchUser();
+      fetchUser({setId, setTeamId, setTeamName, setNotifications});
     }
   }, [id, notifications, teamId, teamName, setId, setTeamId, setNotifications, setTeamName]);
 };

--- a/app/features/user/setting/components/AlertSelect.tsx
+++ b/app/features/user/setting/components/AlertSelect.tsx
@@ -6,16 +6,19 @@ type AlertSelectProps = {
   handleUpdate: () => Promise<void>;
   checked: boolean;
   setChecked: (checked: boolean) => void;
+  labelTitle: string;
+  description: string;
+  groupName: string;
 };
 
-export default function AlertSelect({handleUpdate, checked, setChecked} :AlertSelectProps) {
+export default function AlertSelect({handleUpdate, checked, setChecked, labelTitle, description, groupName} :AlertSelectProps) {
 
   const label = () => {
     return (
       <>
         <div className="flex flex-row justify-start">
           <TriangleIcon className="w-5 h-5 mr-2 text-gray-400" />
-          <div className='text-gray-800'>週間レポート登録をリマインド</div>
+          <div className='text-gray-800'>{labelTitle}</div>
         </div>
       </>
     );
@@ -26,9 +29,9 @@ export default function AlertSelect({handleUpdate, checked, setChecked} :AlertSe
   return (
     <>
       <Radio.Group
-        name="select"
+        name={groupName}
         label={label()}
-        description="ONにすると毎週日曜日にお知らせします"
+        description={description}
         value={checked ? 'true' : 'false'}
         onChange={(value) => setChecked(value === 'true')}
       >

--- a/app/features/user/setting/components/Steps.tsx
+++ b/app/features/user/setting/components/Steps.tsx
@@ -13,13 +13,21 @@ export default function Steps() {
   useFetchUser();
 
   const { notifications, setNotifications } = useUserStore();
+  const { taskNotifications, setTaskNotifications } = useUserStore();
   const [checked, setChecked] = useState(false);
+  const [checkedTask, setCheckedTask] = useState(false);
 
   useEffect(() => {
     if (notifications !== undefined) {
       setChecked(notifications);
     }
   }, [notifications]);
+
+  useEffect(() => {
+    if (taskNotifications !== undefined) {
+      setCheckedTask(taskNotifications);
+    }
+  }, [taskNotifications]);
   
   const handleUpdate = async () => {
     if (checked !== notifications) {
@@ -39,14 +47,34 @@ export default function Steps() {
     }
   };
 
+  const handleUpdateTask = async () => {
+    if (checkedTask !== taskNotifications) {
+      try {
+        await axios.patch('/features/user/api/updateTaskNotification', {
+          user: {
+            task_notifications: checkedTask,
+          },
+        });
+        showSuccessNotification(`更新しました`);
+        setTaskNotifications(checkedTask);
+      } catch (error) {
+        showErrorNotification('更新に失敗しました');
+      }
+    } else {
+      showCautionNotification('設定されています')
+    }
+  };
+
   return (
     <>
       <div className="flex flex-col justify-center w-full max-w-lg">
         <div className='flex justify-end pr-5 pb-2 pt-4'>
           <div className='flex flex-row text-gray-600 text-sm items-center'>
             <BellAlertIcon className="w-4 h-4 mr-1" />
-            <div>現在の設定：</div>
-            <div className='text-gray-700 font-bold'>{notifications ? 'ON' : 'OFF'}</div>
+            <div>レポート：</div>
+            <div className='text-gray-700 font-bold mr-2'>{notifications ? 'ON' : 'OFF'}</div>
+            <div>タスク：</div>
+            <div className='text-gray-700 font-bold'>{taskNotifications ? 'ON' : 'OFF'}</div>
           </div>
         </div>
         <div className="bg-white rounded-md py-7 pl-7">
@@ -65,7 +93,24 @@ export default function Steps() {
             </a>
           </div>
           <div className="flex py-5 pl-4">
-            <AlertSelect handleUpdate={handleUpdate} checked={checked} setChecked={setChecked}/>
+            <AlertSelect 
+              handleUpdate={handleUpdate} 
+              checked={checked} 
+              setChecked={setChecked} 
+              labelTitle="週間レポート登録をリマインド"
+              description="毎週日曜日にお知らせします"
+              groupName='reportAlert'
+              />
+          </div>
+          <div className="flex py-5 pl-4">
+            <AlertSelect 
+              handleUpdate={handleUpdateTask} 
+              checked={checkedTask} 
+              setChecked={setCheckedTask}
+              labelTitle="タスク登録通知"
+              description="チームタスクが登録されるとお知らせします"
+              groupName='taskAlert'
+              />
           </div>
         </div>
       </div>  

--- a/store/userStore.ts
+++ b/store/userStore.ts
@@ -3,11 +3,13 @@ import { create } from 'zustand';
 type UserState = {
   id: number | undefined;
   notifications: boolean | undefined;
+  taskNotifications: boolean | undefined;
   teamId: number | undefined;
   teamName: string | undefined;
   admin: boolean | undefined;
   setId: (id: number) => void;
   setNotifications: (force: boolean) => void;
+  setTaskNotifications: (force: boolean) => void;
   setTeamId: (teamId: number) => void;
   setTeamName: (teamName: string) => void;
   setAdmin: (force: boolean) => void;
@@ -16,11 +18,13 @@ type UserState = {
 const useUserStore = create<UserState>((set) => ({
   id: undefined,
   notifications: undefined,
+  taskNotifications: undefined,
   teamId: undefined,
   teamName: undefined,
   admin: undefined,
   setId: (id) => set(() => ({ id })),
   setNotifications: (notifications) => set(() => ({ notifications })),
+  setTaskNotifications: (taskNotifications) => set(() => ({ taskNotifications })),
   setTeamId: (teamId) => set(() => ({ teamId })),
   setTeamName: (teamName) => set(() => ({ teamName })),
   setAdmin: (admin) => set(() => ({admin})),


### PR DESCRIPTION
## 概要

タスク機能の修正とアップデート

issue: #127 

## 変更点

- 編集ページからチーム作成した際の遷移先の修正（元のページ→最新の所属チームをfetchした上でタスクページに遷移）
- タスクページにヘルプモーダルの追加
- フォームのdescription文言修正
- フォームのdescription文言修正
- タスク用の通知設定をレポートと分けて追加

## 動作確認
macOS, Chromeブラウザ, Node -v18.17.0
- 開発環境で各挙動の確認

## 影響範囲
- team/task
- sample/team
- setting

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応
