### PR TITLE
Team refactor #131

### DIFF
--- a/app/components/page/TeamSetting.tsx
+++ b/app/components/page/TeamSetting.tsx
@@ -1,12 +1,10 @@
 "use client"
 import useUserStore from "@/store/userStore";
 import Loading from "../ui/Loading";
-import useFetchTask from "@/app/features/teamTask/hooks/useTeamTask";
 import EditJoinTeam from "@/app/features/teamJoin/components/EditJoinTeam"
 import TeamIntroduction from "@/app/features/teamJoin/components/TeamIntroduction";
 
 export default function TeamSetting() {
-  useFetchTask();
   const { teamId } = useUserStore();
 
   if (teamId === undefined) {
@@ -14,7 +12,7 @@ export default function TeamSetting() {
   }
   return (
     <div className="flex flex-col justify-center items-center mx-auto px-6 z-0 max-w-4xl my-4">
-      {teamId === 1 ? <TeamIntroduction /> : <EditJoinTeam/> }
+      {teamId === 1 || teamId === null ? <TeamIntroduction /> : <EditJoinTeam/> }
     </div>
   )
 }

--- a/app/components/page/TeamTasks.tsx
+++ b/app/components/page/TeamTasks.tsx
@@ -16,7 +16,7 @@ export default function Teams() {
   return (
     <>
       <div className="flex flex-col justify-center items-center mx-auto px-6 z-0 max-w-4xl my-4">
-        {teamId === 1 ? <TeamIntroduction /> : <TaskTab /> }
+        {teamId === 1 || teamId === null ? <TeamIntroduction /> : <TaskTab /> }
       </div>
     </>
   )

--- a/app/features/teamJoin/api/createTeam/route.ts
+++ b/app/features/teamJoin/api/createTeam/route.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios,  { AxiosError }  from 'axios';
 import { getJwt } from '@/lib/getJwt';
 import { NextRequest } from 'next/server';
 
@@ -45,12 +45,27 @@ export async function POST(req: NextRequest) {
       },
     });
   } catch (error) {
-    console.error(error); 
-    return new Response(JSON.stringify({ error: '予期せぬエラーが発生しました'  }), {
-      status: 500,
-      headers: {
-        "Content-Type": "application/json",
-      },
-    });
+    if (axios.isAxiosError(error)) {
+      console.error(error);
+      // バックエンドからのエラーメッセージを取得
+      const errorMessage = error.response && error.response.data ? error.response.data.error : '予期せぬエラーが発生しました';
+      const status = error.response ? error.response.status : 500;
+  
+      return new Response(JSON.stringify({ error: errorMessage }), {
+        status: status,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+    } else {
+      // その他のエラー
+      console.error('非Axiosエラー', error);
+      return new Response(JSON.stringify({ error: '予期せぬエラーが発生しました' }), {
+        status: 500,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+    }
   }
 }

--- a/app/features/teamJoin/api/joinTeam/route.ts
+++ b/app/features/teamJoin/api/joinTeam/route.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios,  { AxiosError }  from 'axios';
 import { getJwt } from '@/lib/getJwt';
 import { NextRequest } from 'next/server';
 
@@ -45,12 +45,27 @@ export async function POST(req: NextRequest) {
           },
       });
     } catch (error) {
-      console.error(error); 
-      return new Response(JSON.stringify({ error: '予期せぬエラーが発生しました'  }), {
+      if (axios.isAxiosError(error)) {
+        console.error(error);
+        // バックエンドからのエラーメッセージを取得
+        const errorMessage = error.response && error.response.data ? error.response.data.error : '予期せぬエラーが発生しました';
+        const status = error.response ? error.response.status : 500;
+    
+        return new Response(JSON.stringify({ error: errorMessage }), {
+          status: status,
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
+      } else {
+        // その他のエラー
+        console.error('非Axiosエラー', error);
+        return new Response(JSON.stringify({ error: '予期せぬエラーが発生しました' }), {
           status: 500,
           headers: {
             "Content-Type": "application/json",
           },
-      });
+        });
+      }
     }
   }

--- a/app/features/teamJoin/components/TeamMembers.tsx
+++ b/app/features/teamJoin/components/TeamMembers.tsx
@@ -17,7 +17,7 @@ export default function TeamMembers() {
     return <Loading size="xs"/>;
   }
 
-  if (teamId === 1) {
+  if (teamId === 1 || teamId === null) {
     return (
       <div className="flex flex-row items-center">
         <MegaphoneIcon className='w-6 h-6 lg:ml-5 mr-2 text-gray-400' />

--- a/app/features/teamJoin/hooks/fetchTeamMembers.ts
+++ b/app/features/teamJoin/hooks/fetchTeamMembers.ts
@@ -1,0 +1,19 @@
+"use client"
+import { Member } from '@/types';
+import { showErrorNotification } from "@/utils/notifications";
+
+type fetchTeamMembersProps = {
+  setMembers: (members: Member[]) => void;
+}
+
+export  const fetchTeamMembers = async ({setMembers}: fetchTeamMembersProps) => {
+  try {
+    const response = await fetch(`/features/teamJoin/api/getTeamMembers`);
+    const data = await response.json();
+    setMembers(data.members)
+  } catch (error) {
+    console.error(error);
+    showErrorNotification('データの取得に失敗しました');
+  }
+}
+

--- a/app/features/teamJoin/hooks/useTeams.ts
+++ b/app/features/teamJoin/hooks/useTeams.ts
@@ -2,25 +2,15 @@
 import { useEffect } from "react";
 import useTeamStore from "@/store/teamStore";
 import useUserStore from "@/store/userStore";
-import { showErrorNotification } from "@/utils/notifications";
+import { fetchTeamMembers } from "./fetchTeamMembers";
 
 const useFetchTeams = () => {
   const { members, setMembers } = useTeamStore();
   const { teamId } = useUserStore();
 
   useEffect(() => {
-    if (teamId !== 1 && (members?.length === 0 || !members)) {
-      const fetchTeams = async () => {
-        try {
-          const response = await fetch(`/features/teamJoin/api/getTeamMembers`);
-          const data = await response.json();
-          setMembers(data.members)
-        } catch (error) {
-          console.error(error);
-          showErrorNotification('データの取得に失敗しました');
-        }
-      }
-      fetchTeams();
+    if (teamId !== undefined && teamId !== 1 && teamId !== null && (members?.length === 0 || !members)) {
+      fetchTeamMembers({setMembers});
     }
   }, [members, teamId, setMembers]);
 };

--- a/app/features/teamTask/hooks/useTeamTask.ts
+++ b/app/features/teamTask/hooks/useTeamTask.ts
@@ -2,15 +2,17 @@
 import { useEffect } from "react";
 import useTaskStore from "@/store/taskStore";
 import { fetchTasks } from "./fetchTask";
+import useUserStore from "@/store/userStore";
 
 const useFetchTask = () => {
   const { teamTasks, setTeamTasks, userTasks, setUserTasks } = useTaskStore();
+  const { teamId } = useUserStore();
 
   useEffect(() => {
-    if (teamTasks.length === 0 || userTasks.length === 0) {
+    if (teamId !== undefined && teamId !== 1 && teamId !== null && (teamTasks.length === 0 || userTasks.length === 0)) {
       fetchTasks({ setTeamTasks, setUserTasks });
     }
-  },  [teamTasks.length, userTasks.length, setTeamTasks, setUserTasks]);
+  },  [teamTasks.length, userTasks.length, setTeamTasks, setUserTasks, teamId]);
 };
 
 export default useFetchTask;

--- a/app/features/user/hooks/fetchUser.ts
+++ b/app/features/user/hooks/fetchUser.ts
@@ -5,8 +5,8 @@ type FetchUserProps = {
   setId: (id: number) => void;
   setNotifications: (force: boolean) => void;
   setTaskNotifications: (force: boolean) => void;
-  setTeamId: (teamId: number) => void;
-  setTeamName: (teamName: string) => void;
+  setTeamId: (teamId: number | null) => void; 
+  setTeamName: (teamName: string | null) => void;
 }
 
 export  const fetchUser = async ({setId, setNotifications, setTaskNotifications, setTeamId,  setTeamName}: FetchUserProps) => {
@@ -16,8 +16,8 @@ export  const fetchUser = async ({setId, setNotifications, setTaskNotifications,
     setId(data.id)
     setNotifications(data.notifications)
     setTaskNotifications(data.task_notifications)
-    setTeamId(data.group_id)
-    setTeamName(data.group_name)
+    setTeamId(data.group_id ?? null)
+    setTeamName(data.group_name ?? null)
   } catch (error) {
     console.error(error);
     showErrorNotification('データの取得に失敗しました');

--- a/store/userStore.ts
+++ b/store/userStore.ts
@@ -4,14 +4,14 @@ type UserState = {
   id: number | undefined;
   notifications: boolean | undefined;
   taskNotifications: boolean | undefined;
-  teamId: number | undefined;
-  teamName: string | undefined;
+  teamId: number | null | undefined;
+  teamName: string | null | undefined;
   admin: boolean | undefined;
   setId: (id: number) => void;
   setNotifications: (force: boolean) => void;
   setTaskNotifications: (force: boolean) => void;
-  setTeamId: (teamId: number) => void;
-  setTeamName: (teamName: string) => void;
+  setTeamId: (teamId: number | null) => void;
+  setTeamName: (teamName: string | null) => void;
   setAdmin: (force: boolean) => void;
 };
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -97,6 +97,6 @@ export type Member = {
 export type UserStatus = {
   id: number;
   name: string;
-  groupId: number;
+  groupId: number | null;
   roleValue: number;
 };


### PR DESCRIPTION
## 概要

チーム機能のアップデート

issue: #131 

## 変更点

- teamIdがnullのケースを追加
- チーム参加, 作成時のエラーハンドリングを強化（パスワードが違う、名前が被っているなどを明確にする）

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0
- それぞれのケースで期待したレスポンスが受け取れることを確認

## 影響範囲
- /teams/**

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応
