### PR TITLE
Add CustomerType #150 

### DIFF
--- a/app/features/admin/api/customerTypes/route.ts
+++ b/app/features/admin/api/customerTypes/route.ts
@@ -1,8 +1,10 @@
+import axios from 'axios';
 import { getJwt } from '@/lib/getJwt';
 import { NextRequest } from 'next/server';
 import { fetchDataFromApi } from '@/lib/fetchDataFromApi';
 
 const endpoint = "admin/customer_types";
+const apiUrl = process.env.RAILS_API_URL
 
 export async function GET(req: NextRequest) {
   const { accessToken } = await getJwt(req);
@@ -26,6 +28,56 @@ export async function GET(req: NextRequest) {
     });
   } catch (error) {
     return new Response(JSON.stringify({ error:'予期せぬエラーが発生しました' }), {
+      status: 500,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const { accessToken } = await getJwt(req);
+        
+  if (!accessToken) {
+    return new Response(JSON.stringify({ error: '認証が必要です' }), {
+      status: 401,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  }
+
+  const data = await req.json();
+  const customer_type = data.customer_type;
+    
+  if (!customer_type){
+    return new Response(JSON.stringify({ error: 'customer_typeがありません' }), {
+      status: 400,
+      headers: {
+        "Content-Type": "application/json"
+      }
+    });
+  }
+  
+  try {
+    const response = await axios.post(`${apiUrl}/${endpoint}`, { 
+      customer_type
+    }, {
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      }
+    });
+    return new Response(JSON.stringify(response.data), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+  } catch (error) {
+    console.error(error); 
+    return new Response(JSON.stringify({ error: '予期せぬエラーが発生しました'  }), {
       status: 500,
       headers: {
         "Content-Type": "application/json",

--- a/app/features/admin/components/CreateData.tsx
+++ b/app/features/admin/components/CreateData.tsx
@@ -1,0 +1,57 @@
+"use client"
+import { useRouter } from 'next/navigation';
+import axios from 'axios'
+import { z } from 'zod';
+import { useForm } from '@mantine/form';
+import { zodResolver } from 'mantine-form-zod-resolver';
+import { TextInput } from '@mantine/core'
+import PlusButton from '@/app/components/ui/button/PlusButton'
+import { showErrorNotification, showSuccessNotification } from '@/utils/notifications';
+
+type FormValues = {
+  name: string;
+};
+
+const schema = z.object({
+  name: z.string().min(1, {message: '入力してください'}).refine(newContent => newContent.trim().length > 0, '入力してください')
+})
+
+export default function CreateData() {
+  const router = useRouter();
+  
+  const form = useForm({
+    initialValues: {
+      name: '',
+    },
+    validate: zodResolver(schema),
+  });
+
+  const handleSubmit = async (values: FormValues) => {
+    try {
+      await axios.post('/features/admin/api/customerTypes', {
+        customer_type: {
+          name: values.name
+        }
+      })
+      window.location.reload();
+      showSuccessNotification('登録しました');
+    } catch (error) {
+      showErrorNotification('登録に失敗しました')
+    }
+  };
+
+  return (
+    <div className='w-full'>
+      <form onSubmit={form.onSubmit(handleSubmit)}>
+        <TextInput
+          {...form.getInputProps('name')}
+          name='name'
+          label="タイプ名"
+        />
+        <div className="flex justify-center w-full mt-4">
+          <PlusButton size="sm" type="submit">作成する</PlusButton>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/app/features/admin/components/CustomersTable.tsx
+++ b/app/features/admin/components/CustomersTable.tsx
@@ -2,14 +2,18 @@
 import { useEffect, useState } from 'react';
 import axios from 'axios';
 import { showErrorNotification, showSuccessNotification } from '@/utils/notifications';
-import { Table, TextInput } from '@mantine/core';
+import { Table, TextInput, Button, Modal } from '@mantine/core';
+import { PlusIcon } from "@heroicons/react/24/outline"
 import EditIcon from './EditIcon';
 import { CustomerType } from '../types';
+import { useDisclosure } from '@mantine/hooks';
+import CreateData from './CreateData';
 
 export default function CustomersTable() {
   const [customerTypes, setCustomerTypes] = useState<CustomerType[]>([]);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [value, setValue] = useState('');
+  const [opened, { open, close }] = useDisclosure();
 
   const fetchCustomerTypes = async () => {
     try {
@@ -48,7 +52,7 @@ export default function CustomersTable() {
       return;
     }
     try {
-      await axios.delete(`/features/admin/api/users/${id}`);
+      await axios.delete(`/features/admin/api/customerTypes/${id}`);
       showSuccessNotification(`削除しました`);
       fetchCustomerTypes()
       setEditingId(null)
@@ -94,16 +98,34 @@ export default function CustomersTable() {
   ));
   
   return (
-    <Table>
-      <Table.Thead>
-        <Table.Tr>
-          <Table.Th>id</Table.Th>
-          <Table.Th>name</Table.Th>
-          <Table.Th>edit</Table.Th>
-        </Table.Tr>
-      </Table.Thead>
-      <Table.Tbody>{rows}</Table.Tbody>
-    </Table>
+    <>
+      <Table>
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>id</Table.Th>
+            <Table.Th>name</Table.Th>
+            <Table.Th>edit</Table.Th>
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>{rows}</Table.Tbody>
+      </Table>
+      <div className='flex flex-row items-center mt-2'>
+        <Button size="sm" variant="outline" color="#9ca3af" onClick={open}>
+          客層タイプを追加する
+          <PlusIcon className="w-5 h-5 ml-1 text-sky-700" />
+        </Button>
+      </div>
+      <Modal
+        opened={opened}
+        onClose={close}
+        centered
+        size="md"
+      >
+        <div className="flex w-full px-6 py-4">
+          <CreateData/>
+        </div>
+      </Modal>
+    </>
   )
 }
 


### PR DESCRIPTION
## 概要

管理画面から客層タイプの追加ができるよう機能追加

issue: #150 

## 変更点

- admin/customersのアップデート

## 動作確認

macOS, Chromeブラウザ, Node -v18.17.0
- 客層の追加、また本ページへのデータの反映を確認（売上登録の客層選択フォーム, 客層グラフ）

## 影響範囲
- admin/customers

## チェックリスト

- [x] Lintチェックをパスした
- [x] レスポンシブ対応
